### PR TITLE
Add policy to allow lambda to be placed in VPC.

### DIFF
--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -119,5 +119,4 @@ resource "aws_iam_role_policy_attachment" "vpc_access_policy_attachment" {
   count      = local.vpc_config_policy_count
   policy_arn = aws_iam_policy.vpc_access_policy[count.index].arn
   role       = aws_iam_role.lambda_iam_role.name
-
 }

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -32,6 +32,7 @@ resource "aws_lambda_function" "lambda_function" {
   lifecycle {
     ignore_changes = [filename]
   }
+  depends_on = [aws_iam_role_policy_attachment.vpc_access_policy_attachment]
 }
 
 resource "aws_cloudwatch_log_group" "lambda_log_group" {
@@ -41,8 +42,9 @@ resource "aws_cloudwatch_log_group" "lambda_log_group" {
 }
 
 locals {
-  encrypted_env_vars = { for k, v in var.encrypted_env_vars : k => aws_kms_ciphertext.encrypted_environment_variables[k].ciphertext_blob }
-  all_env_vars       = merge(local.encrypted_env_vars, var.plaintext_env_vars)
+  encrypted_env_vars      = { for k, v in var.encrypted_env_vars : k => aws_kms_ciphertext.encrypted_environment_variables[k].ciphertext_blob }
+  all_env_vars            = merge(local.encrypted_env_vars, var.plaintext_env_vars)
+  vpc_config_policy_count = var.vpc_config.subnet_ids == [] ? 0 : 1
 }
 
 resource "aws_kms_ciphertext" "encrypted_environment_variables" {
@@ -104,4 +106,18 @@ resource "aws_iam_role_policy_attachment" "existing_policy_attachment" {
   for_each   = var.policy_attachments
   policy_arn = each.value
   role       = aws_iam_role.lambda_iam_role.name
+}
+
+resource "aws_iam_policy" "vpc_access_policy" {
+  count       = local.vpc_config_policy_count
+  policy      = templatefile("${path.module}/templates/lambda_vpc_policy.json.tpl", {})
+  name        = "${var.function_name}-vpc-policy"
+  description = "Allows access to the VPC for function ${var.function_name}"
+}
+
+resource "aws_iam_role_policy_attachment" "vpc_access_policy_attachment" {
+  count      = local.vpc_config_policy_count
+  policy_arn = aws_iam_policy.vpc_access_policy[count.index].arn
+  role       = aws_iam_role.lambda_iam_role.name
+
 }

--- a/lambda/templates/lambda_vpc_policy.json.tpl
+++ b/lambda/templates/lambda_vpc_policy.json.tpl
@@ -1,0 +1,9 @@
+{
+  "Effect": "Allow",
+  "Action": [
+    "ec2:CreateNetworkInterface",
+    "ec2:DescribeNetworkInterfaces",
+    "ec2:DeleteNetworkInterface"
+  ],
+  "Resource": "*"
+}

--- a/lambda/templates/lambda_vpc_policy.json.tpl
+++ b/lambda/templates/lambda_vpc_policy.json.tpl
@@ -1,9 +1,14 @@
 {
-  "Effect": "Allow",
-  "Action": [
-    "ec2:CreateNetworkInterface",
-    "ec2:DescribeNetworkInterfaces",
-    "ec2:DeleteNetworkInterface"
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateNetworkInterface",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DeleteNetworkInterface"
+      ],
+      "Resource": "*"
+    }
   ],
-  "Resource": "*"
+  "Version": "2012-10-17"
 }

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -6,8 +6,9 @@ data "aws_availability_zones" "available" {
 }
 
 resource "aws_vpc" "main" {
-  cidr_block = var.cidr_block
-
+  cidr_block           = var.cidr_block
+  enable_dns_hostnames = var.enable_dns_hostnames
+  enable_dns_support   = var.enable_dns_support
   tags = merge(
     var.tags,
     tomap(

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -1,5 +1,7 @@
 locals {
-  new_bits = tonumber(split("/", var.subnet_cidr_prefix)[1]) - tonumber(split("/", var.cidr_block)[1])
+  new_bits           = tonumber(split("/", var.subnet_cidr_prefix)[1]) - tonumber(split("/", var.cidr_block)[1])
+  nat_gateway_count  = var.create_nat_gateway ? length(var.elastic_ip_ids) : 0
+  nat_instance_count = var.create_nat_gateway ? 0 : length(var.elastic_ip_ids)
 }
 
 data "aws_availability_zones" "available" {
@@ -61,7 +63,7 @@ resource "aws_route" "internet_access" {
 }
 
 resource "aws_nat_gateway" "gw" {
-  count         = length(var.elastic_ip_ids)
+  count         = local.nat_gateway_count
   subnet_id     = aws_subnet.public.*.id[count.index]
   allocation_id = var.elastic_ip_ids[count.index]
 
@@ -73,50 +75,96 @@ resource "aws_nat_gateway" "gw" {
   )
 }
 
-resource "aws_route_table" "private_nat_gateway" {
-  count  = length(var.elastic_ip_ids)
-  vpc_id = aws_vpc.main.id
 
+resource "aws_route_table" "private_nat_gateway" {
+  count  = local.nat_gateway_count
+  vpc_id = aws_vpc.main.id
   route {
     cidr_block     = "0.0.0.0/0"
     nat_gateway_id = aws_nat_gateway.gw.*.id[count.index]
   }
-
   tags = merge(
     var.tags,
     tomap(
-      { "Name" = "${var.vpc_name}-route-table-${count.index}" }
+      { "Name" = "${var.vpc_name}-nat-gateway-route-table-${count.index}" }
     )
   )
 }
 
 resource "aws_route_table" "private_nat_instance" {
-  count  = length(var.network_interface_ids)
+  count  = local.nat_instance_count
   vpc_id = aws_vpc.main.id
-
-  route {
-    cidr_block           = "0.0.0.0/0"
-    network_interface_id = var.network_interface_ids[count.index]
-  }
-
   tags = merge(
     var.tags,
     tomap(
-      { "Name" = "${var.vpc_name}-route-table-${count.index}" }
+      { "Name" = "${var.vpc_name}-nat-instance-route-table-${count.index}" }
     )
   )
 }
 
-resource "aws_route_table_association" "private_nat_instance" {
-  count     = length(var.network_interface_ids) > 0 ? var.az_count : 0
-  subnet_id = aws_subnet.private.*.id[count.index]
-  // If AZ count is higher than the number of ENI ids provided, assign all remaining subnets to the last ENI
-  route_table_id = count.index > length(var.network_interface_ids) - 1 ? aws_route_table.private_nat_instance.*.id[length(var.network_interface_ids) - 1] : aws_route_table.private_nat_instance.*.id[count.index]
+locals {
+  vpc_az_maps = [
+    for index, rt in aws_route_table.private_nat_instance.*.id
+    : {
+      az                 = aws_subnet.public[index].availability_zone
+      route_table_ids    = [rt]
+      public_subnet_id   = aws_subnet.public[index].id
+      private_subnet_ids = [aws_subnet.private[index].id]
+    }
+  ]
+}
+
+data "aws_network_interface" "interface" {
+  count = local.nat_instance_count
+  filter {
+    name   = "association.allocation-id"
+    values = [var.elastic_ip_ids[count.index]]
+  }
+  depends_on = [module.alternat_instances]
+}
+
+resource "aws_route" "nat_instance_route" {
+  count                  = local.nat_instance_count
+  route_table_id         = aws_route_table.private_nat_instance[count.index].id
+  destination_cidr_block = "0.0.0.0/0"
+  network_interface_id   = data.aws_network_interface.interface[count.index].id
+  depends_on             = [module.alternat_instances]
+}
+
+module "alternat_instances" {
+  count                         = var.create_nat_gateway ? 0 : 1
+  source                        = "git::https://github.com/1debit/alternat.git//modules/terraform-aws-alternat?ref=v0.4.2"
+  lambda_package_type           = "Zip"
+  ingress_security_group_ids    = [var.nat_instance_settings.security_group]
+  vpc_id                        = aws_vpc.main.id
+  vpc_az_maps                   = local.vpc_az_maps
+  create_nat_gateways           = false
+  nat_instance_type             = var.nat_instance_settings.nat_instance_type
+  nat_instance_iam_profile_name = var.nat_instance_settings.nat_instance_iam_profile_name
+  nat_instance_iam_role_name    = var.nat_instance_settings.nat_instance_iam_role_name
+  nat_instance_eip_ids          = var.elastic_ip_ids
+  nat_instance_block_devices = {
+    xvda = {
+      device_name = "/dev/xvda"
+      ebs = {
+        encrypted   = true
+        volume_type = "gp3"
+        volume_size = 20
+      }
+    }
+  }
 }
 
 resource "aws_route_table_association" "private_nat_gateway" {
-  count     = length(var.elastic_ip_ids) > 0 ? var.az_count : 0
+  count     = local.nat_gateway_count > 0 ? var.az_count : 0
   subnet_id = aws_subnet.private.*.id[count.index]
   // If AZ count is higher than the number of elastic IPs provided, assign all remaining subnets to the last NAT gateway
   route_table_id = count.index > length(var.elastic_ip_ids) - 1 ? aws_route_table.private_nat_gateway.*.id[length(var.elastic_ip_ids) - 1] : aws_route_table.private_nat_gateway.*.id[count.index]
+}
+
+resource "aws_route_table_association" "private_nat_instance" {
+  count     = local.nat_instance_count > 0 ? var.az_count : 0
+  subnet_id = aws_subnet.private.*.id[count.index]
+  // If AZ count is higher than the number of elastic IPs provided, assign all remaining subnets to the last NAT gateway
+  route_table_id = count.index > length(var.elastic_ip_ids) - 1 ? aws_route_table.private_nat_instance.*.id[length(var.elastic_ip_ids) - 1] : aws_route_table.private_nat_instance.*.id[count.index]
 }

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -110,7 +110,7 @@ resource "aws_route_table_association" "private_nat_instance" {
   count     = length(var.network_interface_ids) > 0 ? var.az_count : 0
   subnet_id = aws_subnet.private.*.id[count.index]
   // If AZ count is higher than the number of ENI ids provided, assign all remaining subnets to the last ENI
-  route_table_id = count.index > length(var.network_interface_ids) - 1 ? var.network_interface_ids[length(var.network_interface_ids) - 1] : var.network_interface_ids[count.index]
+  route_table_id = count.index > length(var.network_interface_ids) - 1 ? aws_route_table.private_nat_instance.*.id[length(var.network_interface_ids) - 1] : aws_route_table.private_nat_instance.*.id[count.index]
 }
 
 resource "aws_route_table_association" "private_nat_gateway" {

--- a/vpc/outputs.tf
+++ b/vpc/outputs.tf
@@ -2,6 +2,10 @@ output "private_subnets" {
   value = aws_subnet.private.*.id
 }
 
+output "private_route_table_ids" {
+  value = merge(aws_route_table.private_nat_gateway.*.id, aws_route_table.private_nat_instance.*.id)
+}
+
 output "public_subnets" {
   value = aws_subnet.public.*.id
 }

--- a/vpc/outputs.tf
+++ b/vpc/outputs.tf
@@ -13,3 +13,7 @@ output "public_subnets" {
 output "vpc_id" {
   value = aws_vpc.main.id
 }
+
+output "cloud_init" {
+  value = data.cloudinit_config.user_data_config.rendered
+}

--- a/vpc/outputs.tf
+++ b/vpc/outputs.tf
@@ -3,7 +3,7 @@ output "private_subnets" {
 }
 
 output "private_route_table_ids" {
-  value = merge(aws_route_table.private_nat_gateway.*.id, aws_route_table.private_nat_instance.*.id)
+  value = length(aws_route_table.private_nat_gateway) == 0 ? aws_route_table.private_nat_instance.*.id : aws_route_table.private_nat_gateway.*.id
 }
 
 output "public_subnets" {

--- a/vpc/templates/cloud-config.yml
+++ b/vpc/templates/cloud-config.yml
@@ -1,0 +1,9 @@
+repo_update: true
+repo_upgrade: all
+
+packages:
+  - iptables
+
+runcmd:
+  - systemctl enable iptables
+  - systemctl start iptables

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -33,11 +33,13 @@ variable "elastic_ip_ids" {
 
 variable "nat_instance_settings" {
   type = object({
-    security_group                = string
+    security_group                = optional(string)
     nat_instance_type             = optional(string, "t4g.nano")
     nat_instance_iam_profile_name = optional(string)
     nat_instance_iam_role_name    = optional(string)
   })
+  default     = {}
+  description = "Settings for the NAT instance. Must be provided if create_nat_gateway is false"
 }
 
 variable "enable_dns_hostnames" {

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -22,7 +22,8 @@ variable "subnet_cidr_prefix" {
 }
 
 variable "create_nat_gateway" {
-  default = false
+  description = "Will create a NAT gateway when true. Otherwise, it will use https://github.com/1debit/alternat to create a NAT instance"
+  default     = false
 }
 
 variable "elastic_ip_ids" {
@@ -37,6 +38,7 @@ variable "nat_instance_settings" {
     nat_instance_type             = optional(string, "t4g.nano")
     nat_instance_iam_profile_name = optional(string)
     nat_instance_iam_role_name    = optional(string)
+    create_nat_gateway            = optional(bool, true)
   })
   default     = {}
   description = "Settings for the NAT instance. Must be provided if create_nat_gateway is false"

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -21,16 +21,23 @@ variable "subnet_cidr_prefix" {
   description = "The cidr prefix to determine the subnet sizes"
 }
 
+variable "create_nat_gateway" {
+  default = false
+}
+
 variable "elastic_ip_ids" {
-  description = "A list of elastic IPs to assign to the NAT gateway if it is used. Can't be used with network_interface_ids"
+  description = "A list of elastic IPs to assign to the NAT gateway or the NAT instance"
   type        = list(string)
   default     = []
 }
 
-variable "network_interface_ids" {
-  description = "A list of EC2 ENI ids to attach to a route table. Can't be used with elastic_ip_ids"
-  type        = list(string)
-  default     = []
+variable "nat_instance_settings" {
+  type = object({
+    security_group                = string
+    nat_instance_type             = optional(string, "t4g.nano")
+    nat_instance_iam_profile_name = optional(string)
+    nat_instance_iam_role_name    = optional(string)
+  })
 }
 
 variable "enable_dns_hostnames" {

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -32,3 +32,11 @@ variable "network_interface_ids" {
   type        = list(string)
   default     = []
 }
+
+variable "enable_dns_hostnames" {
+  default = true
+}
+
+variable "enable_dns_support" {
+  default = true
+}


### PR DESCRIPTION
I've added in the policy which is required to place the lambda in the
VPC. The main reason is that terraform won't create the role policy
attachments before creating the lambda so if you try and pass these
permissions in, they won't be available to create the lambda. So they
need to be there in the first place.

You can try to set a depends_on on the policies variable but that can
cause circular dependencies if you use the lambda_arn anywhere else.

This is slightly helpful in that we don't have to pass the same
permissions for each lambda we need.
