### PR TITLE
Add nat instance and vpc policy

### DIFF
--- a/lambda/templates/lambda_vpc_policy.json.tpl
+++ b/lambda/templates/lambda_vpc_policy.json.tpl
@@ -1,0 +1,14 @@
+{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateNetworkInterface",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DeleteNetworkInterface"
+      ],
+      "Resource": "*"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -125,6 +125,7 @@ resource "aws_instance" "nat_instance" {
     device_index         = count.index
     network_interface_id = var.network_interface_ids[count.index]
   }
+  source_dest_check           = false
   iam_instance_profile        = aws_iam_instance_profile.instance_profile.id
   user_data_replace_on_change = true
 }

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -130,7 +130,7 @@ resource "aws_instance" "nat_instance" {
   count             = local.count_nat_instance
   ami               = data.aws_ami.ami[0].id
   user_data         = templatefile("${path.module}/templates/nat_instance_user_data.sh.tpl", { vpc_cidr_range = aws_vpc.main.cidr_block })
-  instance_type     = "t3.nano"
+  instance_type     = var.nat_instance_type
   source_dest_check = false
 
   iam_instance_profile        = aws_iam_instance_profile.instance_profile.id

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -125,7 +125,8 @@ resource "aws_instance" "nat_instance" {
     device_index         = count.index
     network_interface_id = var.network_interface_ids[count.index]
   }
-  iam_instance_profile = aws_iam_instance_profile.instance_profile.id
+  iam_instance_profile        = aws_iam_instance_profile.instance_profile.id
+  user_data_replace_on_change = true
 }
 
 resource "aws_iam_role" "instance_role" {

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -78,12 +78,6 @@ resource "aws_route" "internet_access" {
   route_table_id         = aws_vpc.main.main_route_table_id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = aws_internet_gateway.gw.id
-  tags = merge(
-    var.tags,
-    tomap(
-      { "Name" = "${var.vpc_name}-public-route" }
-    )
-  )
 }
 
 resource "aws_nat_gateway" "gw" {
@@ -191,7 +185,7 @@ resource "aws_iam_instance_profile" "instance_profile" {
   tags = merge(
     var.tags,
     tomap(
-      { "Name" = "${var.vpc_name}-nat-instance-profile-${data.aws_availability_zones.available.names[count.index]}" }
+      { "Name" = "${var.vpc_name}-nat-instance-profile" }
     )
   )
 }

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -69,7 +69,7 @@ resource "aws_internet_gateway" "gw" {
   tags = merge(
     var.tags,
     tomap(
-      { "Name" = "${var.vpc_name}-igw-${count.index}" }
+      { "Name" = "${var.vpc_name}-igw-${data.aws_availability_zones.available.names[count.index]}" }
     )
   )
 }
@@ -81,7 +81,7 @@ resource "aws_route" "internet_access" {
   tags = merge(
     var.tags,
     tomap(
-      { "Name" = "${var.vpc_name}-public-route-${count.index}" }
+      { "Name" = "${var.vpc_name}-public-route-${data.aws_availability_zones.available.names[0]}" }
     )
   )
 }
@@ -94,7 +94,7 @@ resource "aws_nat_gateway" "gw" {
   tags = merge(
     var.tags,
     tomap(
-      { "Name" = "${var.vpc_name}-nat-gateway-${count.index}" }
+      { "Name" = "${var.vpc_name}-nat-gateway-${data.aws_availability_zones.available.names[count.index]}" }
     )
   )
 }
@@ -111,7 +111,7 @@ resource "aws_route_table" "private_nat_gateway" {
   tags = merge(
     var.tags,
     tomap(
-      { "Name" = "${var.vpc_name}-nat-gateway-route-table-${count.index}" }
+      { "Name" = "${var.vpc_name}-nat-gateway-route-table-${data.aws_availability_zones.available.names[count.index]}" }
     )
   )
 }
@@ -128,7 +128,7 @@ resource "aws_route_table" "private_nat_instance" {
   tags = merge(
     var.tags,
     tomap(
-      { "Name" = "${var.vpc_name}-nat-instance-route-table-${count.index}" }
+      { "Name" = "${var.vpc_name}-nat-instance-route-table-${data.aws_availability_zones.available.names[count.index]}" }
     )
   )
   depends_on = [aws_instance.nat_instance]

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -69,7 +69,7 @@ resource "aws_internet_gateway" "gw" {
   tags = merge(
     var.tags,
     tomap(
-      { "Name" = "${var.vpc_name}-igw-${data.aws_availability_zones.available.names[count.index]}" }
+      { "Name" = "${var.vpc_name}-igw" }
     )
   )
 }
@@ -81,7 +81,7 @@ resource "aws_route" "internet_access" {
   tags = merge(
     var.tags,
     tomap(
-      { "Name" = "${var.vpc_name}-public-route-${data.aws_availability_zones.available.names[0]}" }
+      { "Name" = "${var.vpc_name}-public-route" }
     )
   )
 }
@@ -175,7 +175,7 @@ resource "aws_iam_role" "instance_role" {
   tags = merge(
     var.tags,
     tomap(
-      { "Name" = "${var.vpc_name}-nat-instance-role-${data.aws_availability_zones.available.names[count.index]}" }
+      { "Name" = "${var.vpc_name}-nat-instance-role" }
     )
   )
 }

--- a/vpc/templates/cloud_config.yml
+++ b/vpc/templates/cloud_config.yml
@@ -1,0 +1,9 @@
+repo_update: true
+repo_upgrade: all
+
+packages:
+  - iptables
+
+runcmd:
+  - systemctl enable iptables
+  - systemctl start iptables

--- a/vpc/templates/cloud_config.yml
+++ b/vpc/templates/cloud_config.yml
@@ -1,9 +1,0 @@
-repo_update: true
-repo_upgrade: all
-
-packages:
-  - iptables
-
-runcmd:
-  - systemctl enable iptables
-  - systemctl start iptables

--- a/vpc/templates/ec2_assume_role.json.tpl
+++ b/vpc/templates/ec2_assume_role.json.tpl
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}

--- a/vpc/templates/nat_instance_user_data.sh.tpl
+++ b/vpc/templates/nat_instance_user_data.sh.tpl
@@ -8,6 +8,8 @@ function die {
 }
 
 log "Enabling PAT..."
+dnf update -y
+dnf install -y iptables
 sysctl -q -w net.ipv4.ip_forward=1 net.ipv4.conf.ens5.send_redirects=0 && (
    iptables -t nat -C POSTROUTING -o ens5 -s ${vpc_cidr_range} -j MASQUERADE 2> /dev/null ||
    iptables -t nat -A POSTROUTING -o ens5 -s ${vpc_cidr_range} -j MASQUERADE ) ||

--- a/vpc/templates/nat_instance_user_data.sh.tpl
+++ b/vpc/templates/nat_instance_user_data.sh.tpl
@@ -1,0 +1,20 @@
+#!/bin/bash
+function log { logger -t "vpc" -- $1; }
+
+function die {
+    [ -n "$1" ] && log "$1"
+    log "Configuration of PAT failed!"
+    exit 1
+}
+
+log "Enabling PAT..."
+sysctl -q -w net.ipv4.ip_forward=1 net.ipv4.conf.ens5.send_redirects=0 && (
+   iptables -t nat -C POSTROUTING -o ens5 -s ${vpc_cidr_range} -j MASQUERADE 2> /dev/null ||
+   iptables -t nat -A POSTROUTING -o ens5 -s ${vpc_cidr_range} -j MASQUERADE ) ||
+       die
+
+sysctl net.ipv4.ip_forward net.ipv4.conf.ens5.send_redirects | log
+iptables -n -t nat -L POSTROUTING | log
+
+log "Configuration of PAT complete."
+exit 0

--- a/vpc/templates/nat_instance_user_data.sh.tpl
+++ b/vpc/templates/nat_instance_user_data.sh.tpl
@@ -3,5 +3,5 @@
 dnf update -y
 dnf install -y iptables
 sysctl -q -w net.ipv4.ip_forward=1 net.ipv4.conf.ens5.send_redirects=0
-iptables -t nat -A POSTROUTING -s -o ens5 ${vpc_cidr_range} -j MASQUERADE
+iptables -t nat -A POSTROUTING -s ${vpc_cidr_range} -j MASQUERADE
 exit 0

--- a/vpc/templates/nat_instance_user_data.sh.tpl
+++ b/vpc/templates/nat_instance_user_data.sh.tpl
@@ -10,12 +10,12 @@ function die {
 log "Enabling PAT"
 dnf update -y
 dnf install -y iptables
-sysctl -q -w net.ipv4.ip_forward=1 net.ipv4.conf.ens5.send_redirects=0 && (
-   iptables -t nat -C POSTROUTING -o ens5 -s ${vpc_cidr_range} -j MASQUERADE 2> /dev/null ||
-   iptables -t nat -A POSTROUTING -o ens5 -s ${vpc_cidr_range} -j MASQUERADE ) ||
+sysctl -q -w net.ipv4.ip_forward=1 net.ipv4.conf.default.send_redirects=0 && (
+   iptables -t nat -C POSTROUTING -o default -s ${vpc_cidr_range} -j MASQUERADE 2> /dev/null ||
+   iptables -t nat -A POSTROUTING -o default -s ${vpc_cidr_range} -j MASQUERADE ) ||
        die
 
-sysctl net.ipv4.ip_forward net.ipv4.conf.ens5.send_redirects | log
+sysctl net.ipv4.ip_forward net.ipv4.conf.default.send_redirects | log
 iptables -n -t nat -L POSTROUTING | log
 
 log "Configuration of PAT complete."

--- a/vpc/templates/nat_instance_user_data.sh.tpl
+++ b/vpc/templates/nat_instance_user_data.sh.tpl
@@ -7,7 +7,7 @@ function die {
     exit 1
 }
 
-log "Enabling PAT..."
+log "Enabling PAT"
 dnf update -y
 dnf install -y iptables
 sysctl -q -w net.ipv4.ip_forward=1 net.ipv4.conf.ens5.send_redirects=0 && (

--- a/vpc/templates/nat_instance_user_data.sh.tpl
+++ b/vpc/templates/nat_instance_user_data.sh.tpl
@@ -1,22 +1,7 @@
 #!/bin/bash
-function log { logger -t "vpc" -- $1; }
 
-function die {
-    [ -n "$1" ] && log "$1"
-    log "Configuration of PAT failed!"
-    exit 1
-}
-
-log "Enabling PAT"
 dnf update -y
 dnf install -y iptables
-sysctl -q -w net.ipv4.ip_forward=1 net.ipv4.conf.default.send_redirects=0 && (
-   iptables -t nat -C POSTROUTING -o default -s ${vpc_cidr_range} -j MASQUERADE 2> /dev/null ||
-   iptables -t nat -A POSTROUTING -o default -s ${vpc_cidr_range} -j MASQUERADE ) ||
-       die
-
-sysctl net.ipv4.ip_forward net.ipv4.conf.default.send_redirects | log
-iptables -n -t nat -L POSTROUTING | log
-
-log "Configuration of PAT complete."
+sysctl -q -w net.ipv4.ip_forward=1 net.ipv4.conf.default.send_redirects=0
+iptables -t nat -A POSTROUTING -s ${vpc_cidr_range} -j MASQUERADE
 exit 0

--- a/vpc/templates/nat_instance_user_data.sh.tpl
+++ b/vpc/templates/nat_instance_user_data.sh.tpl
@@ -2,6 +2,6 @@
 
 dnf update -y
 dnf install -y iptables
-sysctl -q -w net.ipv4.ip_forward=1 net.ipv4.conf.default.send_redirects=0
-iptables -t nat -A POSTROUTING -s ${vpc_cidr_range} -j MASQUERADE
+sysctl -q -w net.ipv4.ip_forward=1 net.ipv4.conf.ens5.send_redirects=0
+iptables -t nat -A POSTROUTING -s -o ens5 ${vpc_cidr_range} -j MASQUERADE
 exit 0

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -21,14 +21,17 @@ variable "subnet_cidr_prefix" {
   description = "The cidr prefix to determine the subnet sizes"
 }
 
-variable "elastic_ip_ids" {
-  description = "A list of elastic IPs to assign to the NAT gateway if it is used. Can't be used with network_interface_ids"
+variable "elastic_ip_allocation_ids" {
+  description = "A list of elastic IPs to assign to the NAT gateway if it is used."
   type        = list(string)
   default     = []
 }
 
-variable "network_interface_ids" {
-  description = "A list of EC2 ENI ids to attach to a route table. Can't be used with elastic_ip_ids"
-  type        = list(string)
-  default     = []
+variable "nat_instance_security_groups" {
+  type    = list(string)
+  default = []
+}
+
+variable "use_nat_gateway" {
+  default = false
 }

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -33,6 +33,11 @@ variable "nat_instance_security_groups" {
   default     = []
 }
 
+variable "nat_instance_type" {
+  description = "The instance type for the NAT instance"
+  default     = "t3.nano"
+}
+
 variable "use_nat_gateway" {
   description = "Will create a nat gateway if set to true and a nat instance otherwise"
   default     = false

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -17,8 +17,8 @@ variable "cidr_block" {
 }
 
 variable "subnet_cidr_prefix" {
-  default     = "/24"
   description = "The cidr prefix to determine the subnet sizes"
+  default     = "/24"
 }
 
 variable "elastic_ip_allocation_ids" {
@@ -28,10 +28,12 @@ variable "elastic_ip_allocation_ids" {
 }
 
 variable "nat_instance_security_groups" {
-  type    = list(string)
-  default = []
+  description = "A list of security groups for the NAT instance"
+  type        = list(string)
+  default     = []
 }
 
 variable "use_nat_gateway" {
-  default = false
+  description = "Will create a nat gateway if set to true and a nat instance otherwise"
+  default     = false
 }


### PR DESCRIPTION
There are two changes:
We're now attaching a policy to the lambda with the ec2 permissions needed to allow it to be created inside the VPC if the VPC arguments are set.
We've also added an option to create a NAT instance instead of a NAT gateway. For both options, you can pass in a list of elastic IPs which will be attached to the instance/gateway. If you don't do this, terraform will create them for you.
