### PR TITLE
Changes to fix lambda, s3 and sns modules.

### DIFF
--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -3,7 +3,7 @@ resource "aws_lambda_function" "lambda_function" {
   handler       = var.handler
   role          = aws_iam_role.lambda_iam_role.arn
   runtime       = var.runtime
-  filename      = startswith(var.runtime, "java") ? "${path.module}/functions/generic.jar" : "${path.module}/functions/generic.zip"
+  filename      = var.filename == "" ? startswith(var.runtime, "java") ? "${path.module}/functions/generic.jar" : "${path.module}/functions/generic.zip" : var.filename
   timeout       = var.timeout_seconds
   memory_size   = var.memory_size
 
@@ -55,7 +55,7 @@ resource "aws_kms_ciphertext" "encrypted_environment_variables" {
 
 resource "aws_lambda_event_source_mapping" "sqs_queue_mappings" {
   for_each                           = var.lambda_sqs_queue_mappings
-  event_source_arn                   = each.key
+  event_source_arn                   = each.value
   function_name                      = aws_lambda_function.lambda_function.*.arn[0]
   batch_size                         = var.sqs_queue_mapping_batch_size
   maximum_batching_window_in_seconds = var.sqs_queue_batching_window

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -64,9 +64,9 @@ variable "vpc_config" {
 }
 
 variable "lambda_sqs_queue_mappings" {
-  type        = set(string)
-  default     = []
-  description = "A list of sqs queue arns which can trigger this lambda"
+  type        = map(string)
+  default     = {}
+  description = "A map of queue name to queue arn to trigger the lambda"
 }
 
 variable "storage_size" {
@@ -105,4 +105,9 @@ variable "sqs_queue_batching_window" {
 
 variable "sqs_queue_concurrency" {
   default = null
+}
+
+variable "filename" {
+  description = "Allows a filename to be passed directly to the module instead of using the generic ones"
+  default     = ""
 }

--- a/s3/main.tf
+++ b/s3/main.tf
@@ -95,3 +95,14 @@ resource "aws_s3_bucket_policy" "logging_bucket_policy" {
   policy     = var.logging_bucket_policy
   depends_on = [aws_s3_bucket_public_access_block.bucket_public_access]
 }
+
+resource "aws_s3_bucket_notification" "bucket_notification" {
+  for_each = var.sns_topic_config
+  bucket   = aws_s3_bucket.bucket.id
+
+  topic {
+    topic_arn = each.value
+    events    = [each.key]
+  }
+}
+

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -15,3 +15,8 @@ variable "logging_bucket_policy" {
 variable "bucket_policy" {
   default = ""
 }
+
+variable "sns_topic_config" {
+  type    = map(string)
+  default = {}
+}

--- a/sns/main.tf
+++ b/sns/main.tf
@@ -16,7 +16,7 @@ resource "aws_sns_topic_subscription" "lambda_subscriptions" {
   endpoint             = each.value
   protocol             = "lambda"
   topic_arn            = aws_sns_topic.sns_topic.arn
-  raw_message_delivery = true
+  raw_message_delivery = false
 }
 
 resource "aws_sns_topic_subscription" "sqs_subscriptions" {

--- a/sns/variables.tf
+++ b/sns/variables.tf
@@ -14,11 +14,13 @@ variable "kms_key_arn" {
 }
 
 variable "lambda_subscriptions" {
-  type        = list(string)
-  description = "A list of lambda arns to subscribe to this topic"
+  type        = map(string)
+  description = "A map of lambda names to arns to subscribe to this topic"
+  default     = {}
 }
 
 variable "sqs_subscriptions" {
-  type        = list(string)
-  description = "A list of SQS arns to subscribe to this topic"
+  type        = map(string)
+  description = "A map of SQS names to arns to subscribe to this topic"
+  default     = {}
 }


### PR DESCRIPTION
* Allow a filename to be passed. Some terraform config repos pass in the code directly so this is useful.
* Replace the sets for the sqs and sns mappings with a map. This is because terraform won't use for_each on a set with values known after apply.
* Stop doing raw message delivery for SNS as it doesn't work.
* Change the bucket notification as that didn't work either.
