### PR TITLE
Add Type tag to KMS admin role.

### DIFF
--- a/kms/main.tf
+++ b/kms/main.tf
@@ -27,7 +27,7 @@ module "kms_admin_role" {
   tags = merge(
     var.tags,
     tomap(
-      { "Name" = "${var.key_name}-admin" }
+      { "Name" = "${var.key_name}-admin", "Type" = "kms-admin-role" }
     )
   )
 }


### PR DESCRIPTION
We would like a cloud custodian role to check to see if any allow
permisisons have been added to the trust policy.

Because a few teams are using cloud custodian, we can't match on the
name so we need a static tag that cloud custodian can find.
