### PR TITLE
Treat missing data as ignore for dlq alarm

### DIFF
--- a/sqs/main.tf
+++ b/sqs/main.tf
@@ -73,6 +73,7 @@ module "dlq_cloudwatch_alarm" {
   threshold           = "0"
   comparison_operator = "GreaterThanThreshold"
   statistic           = "Sum"
+  treat_missing_data  = "ignore"
   datapoints_to_alarm = 1
   dimensions = {
     QueueName = local.sqs_dlq.name


### PR DESCRIPTION
When a queue becomes inactive, it stops sending data to Cloudwatch which
is causing an alert. This should stop it.
