### PR TITLE
Add log group encryption and update redrive policy

### DIFF
--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -37,7 +37,7 @@ resource "aws_lambda_function" "lambda_function" {
 resource "aws_cloudwatch_log_group" "lambda_log_group" {
   name              = "/aws/lambda/${aws_lambda_function.lambda_function.function_name}"
   retention_in_days = var.log_retention
-  kms_key_id        = var.log_group_kms_key
+  kms_key_id        = var.log_group_kms_key_arn
   tags              = var.tags
 }
 
@@ -49,7 +49,7 @@ locals {
 
 resource "aws_kms_ciphertext" "encrypted_environment_variables" {
   for_each  = var.encrypted_env_vars
-  key_id    = var.environment_variables_key_arn
+  key_id    = var.environment_variables_kms_key_arn
   plaintext = each.value
   context   = { "LambdaFunctionName" = var.function_name }
 }

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -37,6 +37,7 @@ resource "aws_lambda_function" "lambda_function" {
 resource "aws_cloudwatch_log_group" "lambda_log_group" {
   name              = "/aws/lambda/${aws_lambda_function.lambda_function.function_name}"
   retention_in_days = var.log_retention
+  kms_key_id        = var.log_group_kms_key
   tags              = var.tags
 }
 
@@ -48,7 +49,7 @@ locals {
 
 resource "aws_kms_ciphertext" "encrypted_environment_variables" {
   for_each  = var.encrypted_env_vars
-  key_id    = var.kms_key_arn
+  key_id    = var.environment_variables_key_arn
   plaintext = each.value
   context   = { "LambdaFunctionName" = var.function_name }
 }

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -6,7 +6,7 @@ variable "handler" {
   description = "The lambda function handler"
 }
 
-variable "kms_key_arn" {
+variable "environment_variables_key_arn" {
   description = "The kms key to use to encrypt environment variables if necessary"
   default     = ""
 }
@@ -61,6 +61,11 @@ variable "vpc_config" {
     subnet_ids         = [],
     security_group_ids = []
   }
+}
+
+variable "log_group_kms_key" {
+  description = "A kms key arn to encrypt the lambda log group with"
+  default     = null
 }
 
 variable "lambda_sqs_queue_mappings" {

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -6,9 +6,9 @@ variable "handler" {
   description = "The lambda function handler"
 }
 
-variable "environment_variables_key_arn" {
+variable "environment_variables_kms_key_arn" {
   description = "The kms key to use to encrypt environment variables if necessary"
-  default     = ""
+  default     = null
 }
 
 variable "encrypted_env_vars" {
@@ -63,7 +63,7 @@ variable "vpc_config" {
   }
 }
 
-variable "log_group_kms_key" {
+variable "log_group_kms_key_arn" {
   description = "A kms key arn to encrypt the lambda log group with"
   default     = null
 }

--- a/sqs/variables.tf
+++ b/sqs/variables.tf
@@ -10,7 +10,7 @@ variable "sqs_policy" {
 }
 
 variable "redrive_maximum_receives" {
-  default = 3
+  default = 10
 }
 
 variable "visibility_timeout" {


### PR DESCRIPTION
There is an optional kms key variable to encrypt the log groups.

There is an existing kms arn variable for encrypting the environment
variables. It's possible that we'd want to use different keys for log
group and env var encryption so I've kept them seperate and updated the
name for the env var one.
