### PR TITLE
DR2-1092 Add extra permissions for the logs service.

### DIFF
--- a/kms/main.tf
+++ b/kms/main.tf
@@ -151,7 +151,13 @@ data "aws_iam_policy_document" "key_policy" {
         type        = "Service"
         identifiers = ["${statement.value}.amazonaws.com"]
       }
-      actions = [
+      actions = startswith(statement.value, "logs.") ? [
+        "kms:Encrypt*",
+        "kms:Decrypt*",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:Describe*"
+        ] : [
         "kms:Decrypt",
         "kms:GenerateDataKey*",
         "kms:DescribeKey"


### PR DESCRIPTION
I was getting errors trying to encrypt a log group with this key.
This page https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html
says that we need extra permissions for logs on the key so I've added
these in.
Other services, sqs/sns etc. seem happy with the permissions they've
already got so I only add the extras for logs.
