### PR TITLE
DR2-1161 feat: Create skeleton step function.

### DIFF
--- a/sfn/main.tf
+++ b/sfn/main.tf
@@ -1,0 +1,13 @@
+resource "aws_sfn_state_machine" "step_function" {
+  name       = var.step_function_name
+  definition = var.step_function_definition
+  role_arn   = module.step_function_role.role_arn
+}
+
+module "step_function_role" {
+  source             = "../iam_role"
+  assume_role_policy = templatefile("${path.module}/templates/sfn_assume_role.json.tpl", {})
+  name               = "${var.step_function_name}-role"
+  tags               = {}
+  policy_attachments = var.step_function_role_policy_attachments
+}

--- a/sfn/outputs.tf
+++ b/sfn/outputs.tf
@@ -1,0 +1,7 @@
+output "step_function_arn" {
+  value = aws_sfn_state_machine.step_function.arn
+}
+
+output "step_function_role_arn" {
+  value = module.step_function_role.role_arn
+}

--- a/sfn/templates/sfn_assume_role.json.tpl
+++ b/sfn/templates/sfn_assume_role.json.tpl
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "states.amazonaws.com"
+      },
+      "Effect": "Allow"
+    }
+  ]
+}

--- a/sfn/variables.tf
+++ b/sfn/variables.tf
@@ -1,0 +1,10 @@
+variable "step_function_name" {}
+
+variable "step_function_definition" {
+  description = "A json string containing the step function definition"
+}
+
+variable "step_function_role_policy_attachments" {
+  description = "A list of policy arns to attach to the step function role"
+  type        = map(string)
+}


### PR DESCRIPTION
This module takes a step function name, a definition as a json string
and a map of policy name -> policy string

This creates a step function with that name from the definition passed in and creates a
role with the provided policies attached.

It outputs the step function arn and the role arn.
