### PR TITLE
DR2-1145 feat: Add secondary indexes and sort keys to module.

### DIFF
--- a/dynamo/main.tf
+++ b/dynamo/main.tf
@@ -3,11 +3,30 @@ resource "aws_dynamodb_table" "table" {
   billing_mode   = var.billing_mode
   read_capacity  = var.billing_mode == "PAY_PER_REQUEST" ? null : var.read_capacity
   write_capacity = var.billing_mode == "PAY_PER_REQUEST" ? null : var.write_capacity
-  hash_key       = var.hash_key
+  hash_key       = var.hash_key.name
+  range_key      = var.range_key.name == null ? null : var.range_key.name
 
-  attribute {
-    name = var.hash_key
-    type = var.hash_key_type
+  dynamic "attribute" {
+    for_each = toset(flatten([var.range_key.name == null ? [] : [var.range_key], var.additional_attributes, [var.hash_key]]))
+    iterator = attr
+    content {
+      name = attr.value.name
+      type = attr.value.type
+    }
+  }
+
+  dynamic "global_secondary_index" {
+    for_each = var.global_secondary_indexes
+    iterator = idx
+    content {
+      name               = idx.value.name
+      hash_key           = idx.value.hash_key
+      range_key          = idx.value.range_key
+      write_capacity     = idx.value.write_capacity
+      read_capacity      = idx.value.read_capacity
+      projection_type    = idx.value.projection_type
+      non_key_attributes = idx.value.non_key_attributes
+    }
   }
 
   tags = merge(

--- a/dynamo/variables.tf
+++ b/dynamo/variables.tf
@@ -12,10 +12,33 @@ variable "write_capacity" {
   default = 5
 }
 
-variable "hash_key" {}
+variable "hash_key" {
+  type = object({ type = string, name = string })
+}
 
-variable "hash_key_type" {}
+variable "range_key" {
+  type    = object({ type = optional(string), name = optional(string) })
+  default = {}
+}
+
+variable "additional_attributes" {
+  type    = list(object({ type = string, name = string }))
+  default = []
+}
 
 variable "common_tags" {
   default = {}
+}
+
+variable "global_secondary_indexes" {
+  type = list(object({
+    name               = string
+    hash_key           = string
+    range_key          = optional(string)
+    write_capacity     = optional(number)
+    read_capacity      = optional(number)
+    projection_type    = string
+    non_key_attributes = optional(list(string), [])
+  }))
+  default = []
 }


### PR DESCRIPTION
Originally the module couldn't add sort keys or global secondary
indexes. I've changed it so you can now.
