### PR TITLE
DR2-1201 Module for EventBridge rule and API destination

### DIFF
--- a/cloudwatch_alarms/main.tf
+++ b/cloudwatch_alarms/main.tf
@@ -8,9 +8,9 @@ resource "aws_cloudwatch_metric_alarm" "cloudwatch_metric_alarm" {
   dimensions          = var.dimensions
   metric_name         = var.metric_name
   namespace           = var.namespace
-  actions_enabled     = var.notification_topic == "" ? false : true
-  alarm_actions       = var.notification_topic == "" ? [] : [var.notification_topic]
-  ok_actions          = var.notification_topic == "" ? [] : [var.notification_topic]
+  actions_enabled     = var.notification_topic == null ? false : true
+  alarm_actions       = var.notification_topic == null ? [] : [var.notification_topic]
+  ok_actions          = var.notification_topic == null ? [] : [var.notification_topic]
   statistic           = var.statistic
   period              = var.period
 }

--- a/eventbridge_api_destination/main.tf
+++ b/eventbridge_api_destination/main.tf
@@ -1,0 +1,21 @@
+resource "aws_cloudwatch_event_connection" "api_connection" {
+  name               = "${var.name}-connection"
+  description        = "A connection for ${var.description}"
+  authorization_type = "API_KEY"
+
+  auth_parameters {
+    api_key {
+      key   = "Authorization"
+      value = var.authorisation_header_value
+    }
+  }
+}
+
+resource "aws_cloudwatch_event_api_destination" "api_destination" {
+  name                             = var.name
+  description                      = var.description
+  invocation_endpoint              = var.invocation_endpoint
+  http_method                      = var.http_method
+  invocation_rate_limit_per_second = var.invocation_rate
+  connection_arn                   = aws_cloudwatch_event_connection.api_connection.arn
+}

--- a/eventbridge_api_destination/outputs.tf
+++ b/eventbridge_api_destination/outputs.tf
@@ -1,0 +1,3 @@
+output "api_destination_arn" {
+  value = aws_cloudwatch_event_api_destination.api_destination.arn
+}

--- a/eventbridge_api_destination/variables.tf
+++ b/eventbridge_api_destination/variables.tf
@@ -1,0 +1,14 @@
+variable "invocation_rate" {
+  default = 300
+}
+variable "http_method" {
+  default = "POST"
+}
+variable "invocation_endpoint" {
+  default = "https://slack.com/api/chat.postMessage"
+}
+variable "description" {
+  default = ""
+}
+variable "name" {}
+variable "authorisation_header_value" {}

--- a/eventbridge_api_destination_rule/main.tf
+++ b/eventbridge_api_destination_rule/main.tf
@@ -1,7 +1,8 @@
 resource "aws_cloudwatch_event_rule" "rule" {
-  name          = var.name
-  description   = var.description
-  event_pattern = var.event_pattern
+  name           = var.name
+  description    = var.description
+  event_pattern  = var.event_pattern
+  event_bus_name = var.event_bus_name
 }
 
 module "api_destination_policy" {
@@ -21,12 +22,13 @@ module "api_destination_role" {
 }
 
 resource "aws_cloudwatch_event_target" "target" {
-  target_id  = var.name
-  arn        = var.api_destination_arn
-  role_arn   = module.api_destination_role.role_arn
-  rule       = aws_cloudwatch_event_rule.rule.name
-  input      = var.input
-  input_path = var.input_path
+  target_id      = var.name
+  event_bus_name = var.event_bus_name
+  arn            = var.api_destination_arn
+  role_arn       = module.api_destination_role.role_arn
+  rule           = aws_cloudwatch_event_rule.rule.name
+  input          = var.input
+  input_path     = var.input_path
   dynamic "input_transformer" {
     for_each = var.input_transformer == null ? [] : [var.input_transformer]
     content {

--- a/eventbridge_api_destination_rule/main.tf
+++ b/eventbridge_api_destination_rule/main.tf
@@ -1,19 +1,19 @@
 resource "aws_cloudwatch_event_rule" "rule" {
-  name        = var.name
-  description = var.description
+  name          = var.name
+  description   = var.description
   event_pattern = var.event_pattern
 }
 
 module "api_destination_policy" {
-  source = "../iam_policy"
-  name   = "${var.name}-policy"
-  policy_string = templatefile("${path.module}/templates/api_destination_policy.json.tpl", {api_destination_arn = var.api_destination_arn})
+  source        = "../iam_policy"
+  name          = "${var.name}-policy"
+  policy_string = templatefile("${path.module}/templates/api_destination_policy.json.tpl", { api_destination_arn = var.api_destination_arn })
 }
 
 module "api_destination_role" {
-  source = "../iam_role"
+  source             = "../iam_role"
   assume_role_policy = templatefile("${path.module}/templates/events_assume_role.json.tpl", {})
-  name = "${var.name}-role"
+  name               = "${var.name}-role"
   policy_attachments = {
     api_destination_policy = module.api_destination_policy.policy_arn
   }
@@ -21,17 +21,17 @@ module "api_destination_role" {
 }
 
 resource "aws_cloudwatch_event_target" "target" {
-  target_id         = var.name
-  arn               = var.api_destination_arn
-  role_arn          = module.api_destination_role.role_arn
-  rule              = aws_cloudwatch_event_rule.rule.name
-  input             = var.input
-  input_path        = var.input_path
+  target_id  = var.name
+  arn        = var.api_destination_arn
+  role_arn   = module.api_destination_role.role_arn
+  rule       = aws_cloudwatch_event_rule.rule.name
+  input      = var.input
+  input_path = var.input_path
   dynamic "input_transformer" {
     for_each = var.input_transformer == null ? [] : [var.input_transformer]
     content {
       input_template = input_transformer.value.input_template
-      input_paths = input_transformer.value.input_paths
+      input_paths    = input_transformer.value.input_paths
     }
   }
 }

--- a/eventbridge_api_destination_rule/main.tf
+++ b/eventbridge_api_destination_rule/main.tf
@@ -1,0 +1,37 @@
+resource "aws_cloudwatch_event_rule" "rule" {
+  name        = var.name
+  description = var.description
+  event_pattern = var.event_pattern
+}
+
+module "api_destination_policy" {
+  source = "../iam_policy"
+  name   = "${var.name}-policy"
+  policy_string = templatefile("${path.module}/templates/api_destination_policy.json.tpl", {api_destination_arn = var.api_destination_arn})
+}
+
+module "api_destination_role" {
+  source = "../iam_role"
+  assume_role_policy = templatefile("${path.module}/templates/events_assume_role.json.tpl", {})
+  name = "${var.name}-role"
+  policy_attachments = {
+    api_destination_policy = module.api_destination_policy.policy_arn
+  }
+  tags = {}
+}
+
+resource "aws_cloudwatch_event_target" "target" {
+  target_id         = var.name
+  arn               = var.api_destination_arn
+  role_arn          = module.api_destination_role.role_arn
+  rule              = aws_cloudwatch_event_rule.rule.name
+  input             = var.input
+  input_path        = var.input_path
+  dynamic "input_transformer" {
+    for_each = var.input_transformer == null ? [] : [var.input_transformer]
+    content {
+      input_template = input_transformer.value.input_template
+      input_paths = input_transformer.value.input_paths
+    }
+  }
+}

--- a/eventbridge_api_destination_rule/templates/api_destination_policy.json.tpl
+++ b/eventbridge_api_destination_rule/templates/api_destination_policy.json.tpl
@@ -1,0 +1,14 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "events:InvokeApiDestination"
+      ],
+      "Resource": [
+        "${api_destination_arn}"
+      ]
+    }
+  ]
+}

--- a/eventbridge_api_destination_rule/templates/events_assume_role.json.tpl
+++ b/eventbridge_api_destination_rule/templates/events_assume_role.json.tpl
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "events.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/eventbridge_api_destination_rule/variables.tf
+++ b/eventbridge_api_destination_rule/variables.tf
@@ -1,0 +1,23 @@
+variable "api_destination_arn" {}
+
+variable "name" {}
+variable "description" {
+  default = ""
+}
+variable "event_pattern" {}
+
+variable "input_transformer" {
+  type = object({
+    input_paths    = map(string)
+    input_template = string
+  })
+  default = null
+}
+
+variable "input" {
+  default = null
+}
+variable "input_path" {
+  default = null
+}
+

--- a/eventbridge_api_destination_rule/variables.tf
+++ b/eventbridge_api_destination_rule/variables.tf
@@ -21,3 +21,6 @@ variable "input_path" {
   default = null
 }
 
+variable "event_bus_name" {
+  default = "default"
+}

--- a/sqs/main.tf
+++ b/sqs/main.tf
@@ -65,6 +65,7 @@ resource "aws_sqs_queue" "dlq_with_sse" {
 }
 
 module "dlq_cloudwatch_alarm" {
+  count               = var.dlq_notification_topic == "" ? 0 : 1
   source              = "../cloudwatch_alarms"
   metric_name         = "ApproximateNumberOfMessagesVisible"
   namespace           = "AWS/SQS"
@@ -77,4 +78,5 @@ module "dlq_cloudwatch_alarm" {
   dimensions = {
     QueueName = local.sqs_dlq.name
   }
+  notification_topic = var.dlq_notification_topic
 }

--- a/sqs/main.tf
+++ b/sqs/main.tf
@@ -65,7 +65,7 @@ resource "aws_sqs_queue" "dlq_with_sse" {
 }
 
 module "dlq_cloudwatch_alarm" {
-  count               = var.dlq_notification_topic == "" ? 0 : 1
+  count               = var.create_cloudwatch_alarm ? 1 : 0
   source              = "../cloudwatch_alarms"
   metric_name         = "ApproximateNumberOfMessagesVisible"
   namespace           = "AWS/SQS"

--- a/sqs/main.tf
+++ b/sqs/main.tf
@@ -65,7 +65,6 @@ resource "aws_sqs_queue" "dlq_with_sse" {
 }
 
 module "dlq_cloudwatch_alarm" {
-  count               = var.dlq_notification_topic == "" ? 0 : 1
   source              = "../cloudwatch_alarms"
   metric_name         = "ApproximateNumberOfMessagesVisible"
   namespace           = "AWS/SQS"
@@ -78,5 +77,4 @@ module "dlq_cloudwatch_alarm" {
   dimensions = {
     QueueName = local.sqs_dlq.name
   }
-  notification_topic = var.dlq_notification_topic
 }

--- a/sqs/outputs.tf
+++ b/sqs/outputs.tf
@@ -15,5 +15,5 @@ output "dlq_sqs_url" {
 }
 
 output "dlq_cloudwatch_alarm_arn" {
-  value = var.dlq_notification_topic == "" ? "" : module.dlq_cloudwatch_alarm.*.cloudwatch_alarm_arn[0]
+  value = module.dlq_cloudwatch_alarm.*.cloudwatch_alarm_arn
 }

--- a/sqs/outputs.tf
+++ b/sqs/outputs.tf
@@ -15,5 +15,5 @@ output "dlq_sqs_url" {
 }
 
 output "dlq_cloudwatch_alarm_arn" {
-  value = module.dlq_cloudwatch_alarm.*.cloudwatch_alarm_arn
+  value = var.dlq_notification_topic == "" ? "" : module.dlq_cloudwatch_alarm.*.cloudwatch_alarm_arn[0]
 }

--- a/sqs/variables.tf
+++ b/sqs/variables.tf
@@ -45,3 +45,8 @@ variable "fifo_queue" {
   type    = bool
   default = false
 }
+
+variable "dlq_notification_topic" {
+  description = "A topic arn which will be used to send ALARM events if a message is put into the DLQ and OK events when it is removed."
+  default     = ""
+}

--- a/sqs/variables.tf
+++ b/sqs/variables.tf
@@ -45,8 +45,3 @@ variable "fifo_queue" {
   type    = bool
   default = false
 }
-
-variable "dlq_notification_topic" {
-  description = "A topic arn which will be used to send ALARM events if a message is put into the DLQ and OK events when it is removed."
-  default     = ""
-}

--- a/sqs/variables.tf
+++ b/sqs/variables.tf
@@ -46,7 +46,11 @@ variable "fifo_queue" {
   default = false
 }
 
+variable "create_cloudwatch_alarm" {
+  default = true
+}
+
 variable "dlq_notification_topic" {
   description = "A topic arn which will be used to send ALARM events if a message is put into the DLQ and OK events when it is removed."
-  default     = ""
+  default     = null
 }


### PR DESCRIPTION
There's a few changes here.

There's a module for the API destination. This is because most
eventbridge rules that are being sent to Slack will go through a single
destination so we'll need to create one and then attach multiple rules
to it.

There's one for the rules. I tried to make it generic but it's tricky so
it only accepts API destinations. If anyone wants other targets, they
can add them.

I've also removed the SNS notification from the SQS module as we don't
need to send cloudwatch alarm notifications via SNS any more.
