### PR TITLE
DR2-1301 Add NACL variables and optional gateway endpoints.

### DIFF
--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -44,3 +44,48 @@ variable "use_nat_gateway" {
 }
 
 variable "environment" {}
+
+variable "private_nacl_rules" {
+  type = set(object({
+    rule_no    = number
+    cidr_block = string
+    action     = string
+    from_port  = number
+    to_port    = number
+    egress     = bool
+  }))
+  default = []
+}
+
+variable "public_nacl_rules" {
+  type = set(object({
+    rule_no    = number
+    cidr_block = string
+    action     = string
+    from_port  = number
+    to_port    = number
+    egress     = bool
+  }))
+  default = []
+}
+
+variable "create_s3_gateway_endpoint" {
+  default = false
+}
+
+variable "create_dynamo_gateway_endpoint" {
+  type    = bool
+  default = false
+}
+
+variable "enable_dns_hostnames" {
+  default = true
+}
+
+variable "enable_dns_support" {
+  default = true
+}
+
+variable "region" {
+  default = "eu-west-2"
+}

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -70,12 +70,12 @@ variable "public_nacl_rules" {
 }
 
 variable "create_s3_gateway_endpoint" {
-  default = false
+  default = true
 }
 
 variable "create_dynamo_gateway_endpoint" {
   type    = bool
-  default = false
+  default = true
 }
 
 variable "enable_dns_hostnames" {


### PR DESCRIPTION
This now has:
* Variables to set NACL rules for public subnets
* Variables to set NACL rules for private subnets
* Variables to enable DNS on the VPC. These are true by default.
* Variables to create gateway endpoints for S3 and Dynamo
