### PR TITLE
Feature dte 915 add permissions boundary argument

### DIFF
--- a/iam_role/main.tf
+++ b/iam_role/main.tf
@@ -1,6 +1,7 @@
 resource "aws_iam_role" "iam_role" {
   assume_role_policy = var.assume_role_policy
   name               = var.name
+  permissions_boundary = var.permissions_boundary
   tags = merge(
     var.tags,
     tomap(

--- a/iam_role/main.tf
+++ b/iam_role/main.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_role" "iam_role" {
-  assume_role_policy = var.assume_role_policy
-  name               = var.name
+  assume_role_policy   = var.assume_role_policy
+  name                 = var.name
   permissions_boundary = var.permissions_boundary
   tags = merge(
     var.tags,

--- a/iam_role/variables.tf
+++ b/iam_role/variables.tf
@@ -16,6 +16,6 @@ variable "tags" {
 
 variable "permissions_boundary" {
   description = "Permissions boundary to attach to the role"
-  type = string
-  default = null
+  type        = string
+  default     = null
 }

--- a/iam_role/variables.tf
+++ b/iam_role/variables.tf
@@ -13,3 +13,9 @@ variable "tags" {
   description = "A list of tags to apply to the resource"
   type        = map(string)
 }
+
+variable "permissions_boundary" {
+  description = "Permissions boundary to attach to the role"
+  type = string
+  default = null
+}

--- a/kms/main.tf
+++ b/kms/main.tf
@@ -4,7 +4,6 @@ resource "aws_kms_key" "encryption" {
   description         = var.key_description
   enable_key_rotation = true
   policy              = var.key_policy == "" ? data.aws_iam_policy_document.key_policy.json : var.key_policy
-  permissions_boundary = var.permissions_boundary
   tags = merge(
     var.tags,
     tomap(
@@ -22,6 +21,7 @@ module "kms_admin_role" {
   source             = "../iam_role"
   assume_role_policy = templatefile("${path.module}/templates/deny_all.json.tpl", {})
   name               = "${var.key_name}-admin"
+  permissions_boundary = var.permissions_boundary
   policy_attachments = {
     kms_power_user = "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
   }

--- a/kms/main.tf
+++ b/kms/main.tf
@@ -18,9 +18,9 @@ resource "aws_kms_alias" "encryption" {
 }
 
 module "kms_admin_role" {
-  source             = "../iam_role"
-  assume_role_policy = templatefile("${path.module}/templates/deny_all.json.tpl", {})
-  name               = "${var.key_name}-admin"
+  source               = "../iam_role"
+  assume_role_policy   = templatefile("${path.module}/templates/deny_all.json.tpl", {})
+  name                 = "${var.key_name}-admin"
   permissions_boundary = var.permissions_boundary
   policy_attachments = {
     kms_power_user = "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"

--- a/kms/main.tf
+++ b/kms/main.tf
@@ -4,6 +4,7 @@ resource "aws_kms_key" "encryption" {
   description         = var.key_description
   enable_key_rotation = true
   policy              = var.key_policy == "" ? data.aws_iam_policy_document.key_policy.json : var.key_policy
+  permissions_boundary = var.permissions_boundary
   tags = merge(
     var.tags,
     tomap(

--- a/kms/variables.tf
+++ b/kms/variables.tf
@@ -35,3 +35,9 @@ variable "default_policy_variables" {
     service_source_account    = ""
   }
 }
+
+variable "permissions_boundary" {
+  description = "Permissions boundary to attach to the role"
+  type = string
+  default = null
+}

--- a/kms/variables.tf
+++ b/kms/variables.tf
@@ -38,6 +38,6 @@ variable "default_policy_variables" {
 
 variable "permissions_boundary" {
   description = "Permissions boundary to attach to the role"
-  type = string
-  default = null
+  type        = string
+  default     = null
 }


### PR DESCRIPTION
TRE would like to use the kms module but require passing through of a permission boundary to create roles.

This is an attempt to add a permission boundary argument to enable this, with null defaults which should be equivalent to not providing the argument at all. Any ideas for a more elegant approach welcome!

## Test plan
Span up a dummy role in local personal workspace with no permission boundary and applied.
```
resource "aws_iam_role" "example_role" {
  name               = "example_role_name"
  assume_role_policy = jsonencode({
    Version   = "2012-10-17",
    Statement = [
      {
        Effect    = "Allow",
        Principal = {
          Service = "ec2.amazonaws.com"
        },
        Action = "sts:AssumeRole"
      },
    ]
  })
}
```
Added `permissions boundary = null argument `and ran a plan, verified matching configuration with no changes.
```
resource "aws_iam_role" "example_role" {
  name               = "example_role_name"
  assume_role_policy = jsonencode({
    Version   = "2012-10-17",
    Statement = [
      {
        Effect    = "Allow",
        Principal = {
          Service = "ec2.amazonaws.com"
        },
        Action = "sts:AssumeRole"
      },
    ]
  })
  permissions_boundary = null
}
```
Ran systems tests on PTE using branch in conjunction with [da-tre-terraform-environments](https://github.com/nationalarchives/da-tre-terraform-environments/pull/310) and [da-tre-tf-module-common](https://github.com/nationalarchives/da-tre-tf-module-common/pull/29) PRs.