### PR TITLE
Add default log bucket policy.

### DIFF
--- a/s3/templates/default_log_bucket_policy.json.tpl
+++ b/s3/templates/default_log_bucket_policy.json.tpl
@@ -1,0 +1,39 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowSSLRequestsOnly",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "s3:*",
+      "Resource": [
+        "arn:aws:s3:::${log_bucket_name}",
+        "arn:aws:s3:::${log_bucket_name}/*"
+      ],
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": "false"
+        }
+      }
+    },
+    {
+      "Sid": "S3ServerAccessLogsPolicy",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "logging.s3.amazonaws.com"
+      },
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Resource": "arn:aws:s3:::${log_bucket_name}/*",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": "arn:aws:s3:::${bucket_name}"
+        },
+        "StringEquals": {
+          "aws:SourceAccount": "${account_id}"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The log buckets need the permissions for logging.s3.amazonaws.com to
PutObject so it makes sense I think to have this as default.

It also enforces SSL.
