### PR TITLE
DR2-1225 Add a new variable to the SQS module

### DIFF
--- a/kms/variables.tf
+++ b/kms/variables.tf
@@ -18,7 +18,7 @@ variable "default_policy_variables" {
   user_roles - A list of roles which will have access to encrypt and decrypt with the key
   ci_roles - Roles to be run by terraform. They have access to administer the key but not decrypt or delete.
   persistent_resource_roles - A list of roles which will allow those roles to grant access to AWS services. See   https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#key-policy-service-integration for more information.
-  service_names - A list of service names, e.g cloudwatch, which will allow decryption from AWS services.
+  service_details - A list of service_detail objects, with a service name and a source account to add to the policy condition. This will allow decryption from AWS services.
   EOT
   type = object({
     user_roles                = optional(list(string), [])

--- a/sqs/main.tf
+++ b/sqs/main.tf
@@ -1,11 +1,11 @@
 locals {
   queue_name_suffix = var.fifo_queue ? ".fifo" : ""
-  sqs_queue         = var.kms_key_id == null ? aws_sqs_queue.sqs_queue_with_sse[0] : aws_sqs_queue.sqs_queue_with_kms[0]
-  sqs_dlq           = var.kms_key_id == null ? aws_sqs_queue.dlq_with_sse[0] : aws_sqs_queue.dlq_with_kms[0]
+  sqs_queue         = var.encryption_type == "sse" ? aws_sqs_queue.sqs_queue_with_sse[0] : aws_sqs_queue.sqs_queue_with_kms[0]
+  sqs_dlq           = var.encryption_type == "sse" ? aws_sqs_queue.dlq_with_sse[0] : aws_sqs_queue.dlq_with_kms[0]
 }
 
 resource "aws_sqs_queue" "sqs_queue_with_sse" {
-  count                     = var.kms_key_id == null ? 1 : 0
+  count                     = var.encryption_type == "sse" ? 1 : 0
   name                      = "${var.queue_name}${local.queue_name_suffix}"
   delay_seconds             = var.delay_seconds
   fifo_queue                = var.fifo_queue
@@ -28,7 +28,7 @@ resource "aws_sqs_queue" "sqs_queue_with_sse" {
 }
 
 resource "aws_sqs_queue" "sqs_queue_with_kms" {
-  count                     = var.kms_key_id == null ? 0 : 1
+  count                     = var.encryption_type == "sse" ? 0 : 1
   name                      = "${var.queue_name}${local.queue_name_suffix}"
   delay_seconds             = var.delay_seconds
   fifo_queue                = var.fifo_queue
@@ -51,14 +51,14 @@ resource "aws_sqs_queue" "sqs_queue_with_kms" {
 }
 
 resource "aws_sqs_queue" "dlq_with_kms" {
-  count                     = var.kms_key_id == null ? 0 : 1
+  count                     = var.encryption_type == "sse" ? 0 : 1
   name                      = "${var.queue_name}-dlq"
   message_retention_seconds = 1209600
   kms_master_key_id         = var.kms_key_id
 }
 
 resource "aws_sqs_queue" "dlq_with_sse" {
-  count                     = var.kms_key_id == null ? 1 : 0
+  count                     = var.encryption_type == "sse" ? 1 : 0
   name                      = "${var.queue_name}-dlq"
   message_retention_seconds = 1209600
   sqs_managed_sse_enabled   = true

--- a/sqs/variables.tf
+++ b/sqs/variables.tf
@@ -50,6 +50,14 @@ variable "create_cloudwatch_alarm" {
   default = true
 }
 
+variable "encryption_type" {
+  default = "kms"
+  validation {
+    condition     = contains(["sse", "kms"], var.encryption_type)
+    error_message = "You must select either sse or kms encryption"
+  }
+}
+
 variable "dlq_notification_topic" {
   description = "A topic arn which will be used to send ALARM events if a message is put into the DLQ and OK events when it is removed."
   default     = null


### PR DESCRIPTION
The problem with running terraform in a clean environment is that we
were using the kms key output in a conditional which terraform doesn't
like.

I've added another parameter which defaults to kms which is used for the
conditionals and doesn't rely on any module creation first. This seems
to have helped a lot.

I've also updated the variable description for the KMS variable as it
was out of date
