### PR TITLE
DR2-1420 Add resources to ignore enabled status.

### DIFF
--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -72,14 +72,6 @@ resource "aws_lambda_event_source_mapping" "sqs_queue_mappings" {
   }
 }
 
-resource "aws_lambda_permission" "sqs_permissions" {
-  for_each      = local.sqs_mapping_without_ignore_enabled
-  action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.lambda_function.function_name
-  principal     = "sqs.amazonaws.com"
-  source_arn    = each.key
-}
-
 resource "aws_lambda_event_source_mapping" "sqs_queue_mappings_ignore_enabled" {
   for_each                           = local.sqs_mapping_ignore_enabled
   event_source_arn                   = each.key
@@ -95,14 +87,6 @@ resource "aws_lambda_event_source_mapping" "sqs_queue_mappings_ignore_enabled" {
   lifecycle {
     ignore_changes = [enabled]
   }
-}
-
-resource "aws_lambda_permission" "sqs_permissions_ignore_enabled" {
-  for_each      = local.sqs_mapping_ignore_enabled
-  action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.lambda_function.function_name
-  principal     = "sqs.amazonaws.com"
-  source_arn    = each.key
 }
 
 resource "aws_lambda_permission" "lambda_permissions" {

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -1,3 +1,7 @@
+locals {
+  sqs_mapping_without_ignore_enabled = { for mapping in var.lambda_sqs_queue_mappings : (mapping.sqs_queue_arn) => mapping.sqs_queue_concurrency if mapping.ignore_enabled_status == false }
+  sqs_mapping_ignore_enabled         = { for mapping in var.lambda_sqs_queue_mappings : (mapping.sqs_queue_arn) => mapping.sqs_queue_concurrency if mapping.ignore_enabled_status == true }
+}
 resource "aws_lambda_function" "lambda_function" {
   function_name = var.function_name
   handler       = var.handler
@@ -55,13 +59,13 @@ resource "aws_kms_ciphertext" "encrypted_environment_variables" {
 }
 
 resource "aws_lambda_event_source_mapping" "sqs_queue_mappings" {
-  for_each                           = var.lambda_sqs_queue_mappings
-  event_source_arn                   = each.value
+  for_each                           = local.sqs_mapping_without_ignore_enabled
+  event_source_arn                   = each.key
   function_name                      = aws_lambda_function.lambda_function.*.arn[0]
   batch_size                         = var.sqs_queue_mapping_batch_size
   maximum_batching_window_in_seconds = var.sqs_queue_batching_window
   dynamic "scaling_config" {
-    for_each = var.sqs_queue_concurrency == null ? [] : [var.sqs_queue_concurrency]
+    for_each = each.value == null ? [] : [each.value]
     content {
       maximum_concurrency = each.value
     }
@@ -69,11 +73,36 @@ resource "aws_lambda_event_source_mapping" "sqs_queue_mappings" {
 }
 
 resource "aws_lambda_permission" "sqs_permissions" {
-  for_each      = var.lambda_sqs_queue_mappings
+  for_each      = local.sqs_mapping_without_ignore_enabled
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.lambda_function.function_name
   principal     = "sqs.amazonaws.com"
-  source_arn    = each.value
+  source_arn    = each.key
+}
+
+resource "aws_lambda_event_source_mapping" "sqs_queue_mappings_ignore_enabled" {
+  for_each                           = local.sqs_mapping_ignore_enabled
+  event_source_arn                   = each.key
+  function_name                      = aws_lambda_function.lambda_function.*.arn[0]
+  batch_size                         = var.sqs_queue_mapping_batch_size
+  maximum_batching_window_in_seconds = var.sqs_queue_batching_window
+  dynamic "scaling_config" {
+    for_each = each.value == null ? [] : [each.value]
+    content {
+      maximum_concurrency = each.value
+    }
+  }
+  lifecycle {
+    ignore_changes = [enabled]
+  }
+}
+
+resource "aws_lambda_permission" "sqs_permissions_ignore_enabled" {
+  for_each      = local.sqs_mapping_ignore_enabled
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.lambda_function.function_name
+  principal     = "sqs.amazonaws.com"
+  source_arn    = each.key
 }
 
 resource "aws_lambda_permission" "lambda_permissions" {

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -69,9 +69,19 @@ variable "log_group_kms_key_arn" {
 }
 
 variable "lambda_sqs_queue_mappings" {
-  type        = map(string)
-  default     = {}
-  description = "A map of queue name to queue arn to trigger the lambda"
+  type = list(object({
+    sqs_queue_arn         = string
+    sqs_queue_concurrency = optional(number, null)
+    ignore_enabled_status = optional(bool, false)
+  }))
+  default     = []
+  description = <<EOT
+    A list of objects to create SQS queue mappings
+    sqs_queue_arn: The queue arn to map to the lambda
+    sqs_queue_concurrency: The concurrency of the queue mapping
+    ignore_enabled_status: Whether to ignore the status of the mapping. This is useful if you want to disable the mapping
+    manually without terraform overwriting it.
+  EOT
 }
 
 variable "storage_size" {
@@ -106,10 +116,6 @@ variable "sqs_queue_mapping_batch_size" {
 
 variable "sqs_queue_batching_window" {
   default = 0
-}
-
-variable "sqs_queue_concurrency" {
-  default = null
 }
 
 variable "filename" {


### PR DESCRIPTION
I've refactored the sqs_queue_mappings variable to take a parameter to
ignore the enabled status for that queue mapping.

This means we can have one queue mapping where we ignore the status and
one without rather than having it set globally.

Terraform doesn't allow conditional ignores on resources so we have to
duplicate the resources and filter the set passed to the foreach.

I've also added the queue concurrency to the object so this can be set
per mapping rather than globally for all mappings.
