### PR TITLE
DR2-1444 Add log group target

### DIFF
--- a/eventbridge_api_destination_rule/variables.tf
+++ b/eventbridge_api_destination_rule/variables.tf
@@ -6,8 +6,17 @@ variable "description" {
 }
 variable "event_pattern" {}
 
-variable "input_transformer" {
+variable "api_destination_input_transformer" {
   type = object({
+    input_paths    = map(string)
+    input_template = string
+  })
+  default = null
+}
+
+variable "log_group_destination_input_transformer" {
+  type = object({
+    log_group_name = string
     input_paths    = map(string)
     input_template = string
   })


### PR DESCRIPTION
This lets us add an additional cloudwatch log group target. This
(should) be useful for monitoring step function failures and other
things that fail.
