### PR TITLE
TDR 46: Add Cloudfront distributions support to KMS module

### DIFF
--- a/kms/main.tf
+++ b/kms/main.tf
@@ -173,23 +173,27 @@ data "aws_iam_policy_document" "key_policy" {
     }
   }
 
-  statement {
-    sid    = "CloudfrontDecryptAndEncrypt"
-    effect = "Allow"
-    principals {
-      type        = "Service"
-      identifiers = ["cloudfront.amazonaws.com"]
-    }
-    actions = [
-      "kms:Decrypt",
-      "kms:Encrypt",
-      "kms:GenerateDataKey*",
-    ]
-    resources = ["*"]
-    condition {
-      test     = "StringEquals"
-      variable = "aws:SourceArn"
-      values   = var.default_policy_variables.cloudfront_distributions
+  dynamic statement {
+    for_each = length(var.default_policy_variables.cloudfront_distributions) == 0 ? [] : ["cloudfront_distributions"]
+
+    content {
+      sid    = "CloudfrontDecryptAndEncrypt"
+      effect = "Allow"
+      principals {
+        type        = "Service"
+        identifiers = ["cloudfront.amazonaws.com"]
+      }
+      actions = [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+      ]
+      resources = ["*"]
+      condition {
+        test     = "StringEquals"
+        variable = "aws:SourceArn"
+        values   = var.default_policy_variables.cloudfront_distributions
+      }
     }
   }
 }

--- a/kms/main.tf
+++ b/kms/main.tf
@@ -172,4 +172,24 @@ data "aws_iam_policy_document" "key_policy" {
       }
     }
   }
+
+  statement {
+    sid       = "CloudfrontDecryptAndEncrypt"
+    effect    = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+    actions = [
+      "kms:Decrypt",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = var.default_policy_variables.cloudfront_distributions
+    }
+  }
 }

--- a/kms/main.tf
+++ b/kms/main.tf
@@ -174,8 +174,8 @@ data "aws_iam_policy_document" "key_policy" {
   }
 
   statement {
-    sid       = "CloudfrontDecryptAndEncrypt"
-    effect    = "Allow"
+    sid    = "CloudfrontDecryptAndEncrypt"
+    effect = "Allow"
     principals {
       type        = "Service"
       identifiers = ["cloudfront.amazonaws.com"]

--- a/kms/main.tf
+++ b/kms/main.tf
@@ -173,7 +173,7 @@ data "aws_iam_policy_document" "key_policy" {
     }
   }
 
-  dynamic statement {
+  dynamic "statement" {
     for_each = length(var.default_policy_variables.cloudfront_distributions) == 0 ? [] : ["cloudfront_distributions"]
 
     content {

--- a/kms/variables.tf
+++ b/kms/variables.tf
@@ -28,12 +28,14 @@ variable "default_policy_variables" {
       service_name           = string
       service_source_account = optional(string, null)
     })), [])
+    cloudfront_distributions = optional(list(string), [])
   })
   default = {
     user_roles                = []
     persistent_resource_roles = []
     ci_roles                  = []
     service_details           = []
+    cloudfront_distributions = []
   }
 }
 

--- a/kms/variables.tf
+++ b/kms/variables.tf
@@ -35,7 +35,7 @@ variable "default_policy_variables" {
     persistent_resource_roles = []
     ci_roles                  = []
     service_details           = []
-    cloudfront_distributions = []
+    cloudfront_distributions  = []
   }
 }
 


### PR DESCRIPTION
We have use case in TDR where we need to give our cloudfront distribution permission to use a customer managed KMS key.

The statement structure for this differs slightly than those already supported for IAM roles or services, so this PR introduces a new dedicated policy variable. With an empty list default for distribution arns, this shouldn't impact any existing keys on submodule upgrade.

---

### Test Plan
Tested with https://github.com/nationalarchives/tdr-terraform-environments/pull/429 ; verified upload to cloudfront working with encryption both on and off