### PR TITLE
DR2-1676 Require Dynamo requests use SSL.

### DIFF
--- a/dynamo/main.tf
+++ b/dynamo/main.tf
@@ -49,5 +49,5 @@ resource "aws_dynamodb_table" "table" {
 
 resource "aws_dynamodb_resource_policy" "require_ssl" {
   resource_arn = aws_dynamodb_table.table.arn
-  policy       = templatefile("${path.module}/templates/dynamo_require_ssl.json.tpl", {table_arn = aws_dynamodb_table.table.arn})
+  policy       = templatefile("${path.module}/templates/dynamo_require_ssl.json.tpl", { table_arn = aws_dynamodb_table.table.arn })
 }

--- a/dynamo/main.tf
+++ b/dynamo/main.tf
@@ -46,3 +46,8 @@ resource "aws_dynamodb_table" "table" {
     )
   )
 }
+
+resource "aws_dynamodb_resource_policy" "require_ssl" {
+  resource_arn = aws_dynamodb_table.table.arn
+  policy       = templatefile("${path.module}/templates/dynamo_require_ssl.json.tpl", {table_arn = aws_dynamodb_table.table.arn})
+}

--- a/dynamo/templates/dynamo_require_ssl.json.tpl
+++ b/dynamo/templates/dynamo_require_ssl.json.tpl
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowSSLRequestsOnly",
+      "Principal": "*",
+      "Action": "dynamodb:*",
+      "Effect": "Deny",
+      "Resource": "${table_arn}",
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": "false"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This will apply by default in the module.
