### PR TITLE
DR2-1668 Use RATE for DLQ alarms.

### DIFF
--- a/sqs/main.tf
+++ b/sqs/main.tf
@@ -64,20 +64,42 @@ resource "aws_sqs_queue" "dlq_with_sse" {
   sqs_managed_sse_enabled   = true
 }
 
-module "dlq_cloudwatch_alarm" {
-  source              = "../cloudwatch_alarms"
-  metric_name         = "ApproximateNumberOfMessagesVisible"
-  namespace           = "AWS/SQS"
-  name                = "${var.queue_name}-messages-visible--dlq-alarm"
-  threshold           = var.dlq_cloudwatch_alarm_visible_messages_threshold
+resource "aws_cloudwatch_metric_alarm" "dlq_metric_alarm" {
+  alarm_name          = "${var.queue_name}-messages-visible--dlq-alarm"
   comparison_operator = "GreaterThanThreshold"
-  statistic           = "Sum"
-  treat_missing_data  = "ignore"
-  datapoints_to_alarm = 1
-  dimensions = {
-    QueueName = local.sqs_dlq.name
+  evaluation_periods  = 60
+  metric_query {
+    id = "m1"
+    metric {
+      dimensions = {
+        QueueName = "${var.queue_name}-dlq"
+      }
+      metric_name = "ApproximateNumberOfMessagesVisible"
+      period      = 60
+      stat        = "Maximum"
+      namespace   = "AWS/SQS"
+    }
   }
-  notification_topic = var.dlq_notification_topic
+  metric_query {
+    id = "m2"
+    metric {
+      dimensions = {
+        QueueName = "${var.queue_name}-dlq"
+      }
+      metric_name = "ApproximateNumberOfMessagesVisible"
+      period      = 60
+      stat        = "Maximum"
+      namespace   = "AWS/SQS"
+    }
+  }
+  metric_query {
+    expression  = "RATE(m1+m2)"
+    id          = "e1"
+    label       = "AllMessagesInQueue"
+    period      = 60
+    return_data = true
+  }
+
 }
 
 module "queue_cloudwatch_alarm" {

--- a/sqs/main.tf
+++ b/sqs/main.tf
@@ -86,7 +86,7 @@ resource "aws_cloudwatch_metric_alarm" "dlq_metric_alarm" {
       dimensions = {
         QueueName = "${var.queue_name}-dlq"
       }
-      metric_name = "ApproximateNumberOfMessagesVisible"
+      metric_name = "ApproximateNumberOfMessagesNotVisible"
       period      = 60
       stat        = "Maximum"
       namespace   = "AWS/SQS"

--- a/sqs/main.tf
+++ b/sqs/main.tf
@@ -67,7 +67,7 @@ resource "aws_sqs_queue" "dlq_with_sse" {
 resource "aws_cloudwatch_metric_alarm" "dlq_metric_alarm" {
   alarm_name          = "${var.queue_name}-messages-visible--dlq-alarm"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 60
+  evaluation_periods  = var.dlq_alarm_evaluation_period
   metric_query {
     id = "m1"
     metric {
@@ -75,7 +75,7 @@ resource "aws_cloudwatch_metric_alarm" "dlq_metric_alarm" {
         QueueName = "${var.queue_name}-dlq"
       }
       metric_name = "ApproximateNumberOfMessagesVisible"
-      period      = 60
+      period      = var.dlq_alarm_evaluation_period
       stat        = "Maximum"
       namespace   = "AWS/SQS"
     }
@@ -87,7 +87,7 @@ resource "aws_cloudwatch_metric_alarm" "dlq_metric_alarm" {
         QueueName = "${var.queue_name}-dlq"
       }
       metric_name = "ApproximateNumberOfMessagesNotVisible"
-      period      = 60
+      period      = var.dlq_alarm_evaluation_period
       stat        = "Maximum"
       namespace   = "AWS/SQS"
     }

--- a/sqs/outputs.tf
+++ b/sqs/outputs.tf
@@ -15,5 +15,5 @@ output "dlq_sqs_url" {
 }
 
 output "dlq_cloudwatch_alarm_arn" {
-  value = var.dlq_notification_topic == "" ? "" : module.dlq_cloudwatch_alarm.*.cloudwatch_alarm_arn[0]
+  value = aws_cloudwatch_metric_alarm.dlq_metric_alarm.arn
 }

--- a/sqs/variables.tf
+++ b/sqs/variables.tf
@@ -73,3 +73,9 @@ variable "queue_visibility_alarm_notification_topic" {
   description = "A topic arn which will be used to send ALARM events if the alarm for max number of messages in the queue is triggered."
   default     = null
 }
+
+variable "dlq_alarm_evaluation_period" {
+  type        = number
+  description = "The evaluation period for the metrics for the DLQ alarm"
+  default     = 60
+}


### PR DESCRIPTION
The issue is that if we get a message in a DLQ where there is already a
message in the DLQ, we don't get another notification.

Repeating messages for alarms that don't change state is a bit
complicated so we'll go with this as a solution now.

The period is 60 seconds so we shouldn't get massively spammed by a huge
number of messages entering the DLQ at once.
