### PR TITLE
Uppdate abort_incomplete_multipart_upload_days default value to 7

### DIFF
--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -27,5 +27,5 @@ variable "kms_key_arn" {
 
 variable "abort_incomplete_multipart_upload_days" {
   description = "The number of days to keep an incomplete multipart upload before it is deleted"
-  default     = 30
+  default     = 7
 }


### PR DESCRIPTION
Update abort_incomplete_multipart_upload_days default value to 7 in line with https://national-archives.atlassian.net/wiki/spaces/DAAE/pages/395477060/Simple+Storage+Service+S3#S3-Buckets