### PR TITLE
Update notification_topic default to null

### DIFF
--- a/cloudwatch_alarms/variables.tf
+++ b/cloudwatch_alarms/variables.tf
@@ -35,7 +35,7 @@ variable "name" {
 }
 
 variable "notification_topic" {
-  default     = ""
+  default     = null
   description = "The SNS topic to send alarm notifications to"
 }
 


### PR DESCRIPTION
Update notification_topic default to null to fix terraform plan inconsistency when not providing a notification topic like we do in ayr and ddt following https://national-archives.atlassian.net/wiki/spaces/DDT/pages/411926532/ADR-011+Observability+-+Alerting+Infrastructure:

This kept showing in plan even after apply since default was empty string but that gets removed when terraform apply is run.

<img width="895" alt="Screenshot 2024-06-12 at 14 57 18" src="https://github.com/nationalarchives/da-terraform-modules/assets/42998618/5a0f507f-f261-4495-af9d-53951f7f3c45">


corresponding code:

<img width="852" alt="Screenshot 2024-06-12 at 14 59 07" src="https://github.com/nationalarchives/da-terraform-modules/assets/42998618/2cfe7b7a-c7ec-4b9e-849b-9f5269324f89">



This fixes this