### PR TITLE
Make s3 bucket policy extend default ssl policy

### DIFF
--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -13,7 +13,8 @@ variable "logging_bucket_policy" {
 }
 
 variable "bucket_policy" {
-  default = ""
+  default     = ""
+  description = "Additional bucket policy to be added to a default policy with sid AllowSSLRequestsOnly that denies non SSL requests."
 }
 
 variable "sns_topic_config" {


### PR DESCRIPTION
Make s3 bucket policy extend default ssl policy so that we can pass in a policy with extra restrictions but always deny ssl requests as per https://national-archives.atlassian.net/wiki/spaces/DAAE/pages/395477060/Simple+Storage+Service+S3

In action in AYR repo (temporarily pointed it to this branch): 
https://github.com/nationalarchives/da-ayr-terraform/pull/166
https://github.com/nationalarchives/da-ayr-terraform/actions/runs/9498690780/job/26177949659

<img width="1186" alt="Screenshot 2024-06-13 at 12 20 31" src="https://github.com/nationalarchives/da-terraform-modules/assets/42998618/fd3b65a1-8e3b-43a5-9828-30a6a7c72807">
