### PR TITLE
Require log_bucket_name if create_log_bucket not specified

### DIFF
--- a/s3/main.tf
+++ b/s3/main.tf
@@ -1,6 +1,6 @@
 locals {
   log_bucket_count = var.create_log_bucket ? 1 : 0
-  log_bucket_name  = "${var.bucket_name}-logs"
+  log_bucket_name  = var.create_log_bucket ? "${var.bucket_name}-logs" : var.log_bucket_name
 }
 
 resource "aws_s3_bucket" "bucket" {
@@ -115,10 +115,9 @@ resource "aws_s3_bucket_versioning" "logging_versioning_example" {
 }
 
 resource "aws_s3_bucket_logging" "bucket_logging" {
-  count  = local.log_bucket_count
-  bucket = aws_s3_bucket.bucket.id
+  bucket = var.bucket_name
 
-  target_bucket = aws_s3_bucket.logging_bucket[count.index].id
+  target_bucket = local.log_bucket_name
   target_prefix = "${var.bucket_name}/${data.aws_caller_identity.current.account_id}/"
 }
 

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -2,6 +2,10 @@ variable "create_log_bucket" {
   default = true
 }
 
+variable "log_bucket_name" {
+  default = ""
+}
+
 variable "bucket_name" {}
 
 variable "common_tags" {


### PR DESCRIPTION
Require externally created log_bucket_name if create_log_bucket not specified.

This is due to Kurti and Paul's new suggestion to have 1 access log bucket per account as opposed to 1 log bucket per data bucket, but at the same time is backwards compatible for current setups which do utilise that. Eventually if we really push for this we can remove the log bucket creation from this module.


I have a followup PR to create a s3_logs module that will individually create a bucket configured for logging.