### PR TITLE
Treat missing data as not breaching.

### DIFF
--- a/sqs/main.tf
+++ b/sqs/main.tf
@@ -68,7 +68,7 @@ resource "aws_cloudwatch_metric_alarm" "dlq_metric_alarm" {
   alarm_name          = "${var.queue_name}-messages-visible--dlq-alarm"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.dlq_alarm_evaluation_period
-  treat_missing_data  = "notBreaching"
+  treat_missing_data  = "ignore"
   metric_query {
     id = "m1"
     metric {

--- a/sqs/main.tf
+++ b/sqs/main.tf
@@ -68,6 +68,7 @@ resource "aws_cloudwatch_metric_alarm" "dlq_metric_alarm" {
   alarm_name          = "${var.queue_name}-messages-visible--dlq-alarm"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.dlq_alarm_evaluation_period
+  treat_missing_data  = "notBreaching"
   metric_query {
     id = "m1"
     metric {


### PR DESCRIPTION
We're getting alerts for the alarm being OK without it being in alarm
first. This is probably because sqs stops reporting to Cloudwatch and
we're treating missing data as missing.

This will treat missing data as OK which is fine because it means the
queue is empty.
