### PR TITLE
Add count to bucket_logging resource.

### DIFF
--- a/s3/main.tf
+++ b/s3/main.tf
@@ -115,6 +115,7 @@ resource "aws_s3_bucket_versioning" "logging_versioning_example" {
 }
 
 resource "aws_s3_bucket_logging" "bucket_logging" {
+  count  = local.log_bucket_count
   bucket = var.bucket_name
 
   target_bucket = local.log_bucket_name


### PR DESCRIPTION
As it is, this tries to create a bucket_logging resource without the
logging bucket being created which causes an error.
