### PR TITLE
DR2-1770-Update-da-terraform-modules-to-allow-Dynamo-Stream

### DIFF
--- a/dynamo/main.tf
+++ b/dynamo/main.tf
@@ -6,8 +6,8 @@ resource "aws_dynamodb_table" "table" {
   hash_key                    = var.hash_key.name
   range_key                   = var.range_key.name == null ? null : var.range_key.name
   deletion_protection_enabled = var.deletion_protection_enabled
-  stream_enabled              = true
-  stream_view_type            = "NEW_AND_OLD_IMAGES"
+  stream_enabled              = var.stream_enabled
+  stream_view_type            = var.stream_enabled == false ? null : "NEW_IMAGE"
 
   point_in_time_recovery {
     enabled = var.point_in_time_recovery_enabled

--- a/dynamo/main.tf
+++ b/dynamo/main.tf
@@ -7,7 +7,7 @@ resource "aws_dynamodb_table" "table" {
   range_key                   = var.range_key.name == null ? null : var.range_key.name
   deletion_protection_enabled = var.deletion_protection_enabled
   stream_enabled              = var.stream_enabled
-  stream_view_type            = var.stream_enabled == false ? null : "NEW_IMAGE"
+  stream_view_type            = var.stream_enabled == false ? null : var.stream_view_type
 
   point_in_time_recovery {
     enabled = var.point_in_time_recovery_enabled

--- a/dynamo/main.tf
+++ b/dynamo/main.tf
@@ -6,6 +6,8 @@ resource "aws_dynamodb_table" "table" {
   hash_key                    = var.hash_key.name
   range_key                   = var.range_key.name == null ? null : var.range_key.name
   deletion_protection_enabled = var.deletion_protection_enabled
+  stream_enabled              = true
+  stream_view_type            = "NEW_AND_OLD_IMAGES"
 
   point_in_time_recovery {
     enabled = var.point_in_time_recovery_enabled

--- a/dynamo/outputs.tf
+++ b/dynamo/outputs.tf
@@ -1,3 +1,7 @@
 output "table_arn" {
   value = aws_dynamodb_table.table.arn
 }
+
+output "stream_arn" {
+  value = aws_dynamodb_table.table.stream_arn
+}

--- a/dynamo/variables.tf
+++ b/dynamo/variables.tf
@@ -72,3 +72,7 @@ variable "stream_enabled" {
   type    = bool
   default = false
 }
+
+variable "stream_view_type" {
+  default = "NEW_IMAGE"
+}

--- a/dynamo/variables.tf
+++ b/dynamo/variables.tf
@@ -67,3 +67,8 @@ variable "ttl_attribute_name" {
   description = "This attribute name will be used to enable ttl on the table"
   default     = null
 }
+
+variable "stream_enabled" {
+  type = bool
+  default = false
+}

--- a/dynamo/variables.tf
+++ b/dynamo/variables.tf
@@ -69,6 +69,6 @@ variable "ttl_attribute_name" {
 }
 
 variable "stream_enabled" {
-  type = bool
+  type    = bool
   default = false
 }


### PR DESCRIPTION
Module updated to enable dynamo stream. It is done through a variable with default value of `false` 
Any table that wants to enable streams can pass `true` to the module.

If stream is enabled, the view type is automatically set to `NEW_IMAGE` 