### PR TITLE
Remove handler from ecr lambda

### DIFF
--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -45,7 +45,6 @@ resource "aws_lambda_function" "lambda_function" {
 resource "aws_lambda_function" "lambda_function_ecr" {
   count         = var.use_image ? 1 : 0
   function_name = var.function_name
-  handler       = var.handler
   role          = aws_iam_role.lambda_iam_role.arn
   image_uri     = var.image_url
   package_type  = "Image"

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -4,6 +4,7 @@ variable "function_name" {
 
 variable "handler" {
   description = "The lambda function handler"
+  default     = null
 }
 
 variable "environment_variables_kms_key_arn" {


### PR DESCRIPTION
An image lambda function does not require a handler - will be ignored in AWS
When using the module to create an image lambda it does not make sense to have to set the handler variable so defaulting it to null so it is not required