### PR TITLE
Generalise log bucket policy for other log sources

### DIFF
--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -13,7 +13,7 @@ variable "common_tags" {
 }
 
 variable "logging_bucket_policy" {
-  default = ""
+  default = "Additional logging bucket policy to be added to a default policy."
 }
 
 variable "bucket_policy" {

--- a/s3_logs/main.tf
+++ b/s3_logs/main.tf
@@ -1,6 +1,7 @@
 module "log_bucket" {
   source = "../s3_prototype"
 
+  attach_s3_policy                       = var.attach_s3_policy
   bucket_name                            = var.bucket_name
   common_tags                            = var.common_tags
   bucket_policy                          = var.bucket_policy

--- a/s3_logs/outputs.tf
+++ b/s3_logs/outputs.tf
@@ -1,0 +1,4 @@
+output "s3_bucket_policy_json" {
+  description = "s3 bucket policy json intended to be merged with other policies for the bucket built outside of the module if var.attach_s3_policy is false due to circular dependencies."
+  value       = module.log_bucket.s3_bucket_policy_json
+}

--- a/s3_logs/variables.tf
+++ b/s3_logs/variables.tf
@@ -1,3 +1,9 @@
+variable "attach_s3_policy" {
+  description = "Whether to attach s3 bucket policy built by the inputted bucket_policy and default policies or not. Only expected to be false if the full bucket policy cannot be passesd in due to a circular dependency"
+  type        = bool
+  default     = true
+}
+
 variable "bucket_name" {}
 
 variable "common_tags" {

--- a/s3_prototype/main.tf
+++ b/s3_prototype/main.tf
@@ -65,7 +65,8 @@ data "aws_iam_policy_document" "policy_document" {
 }
 
 resource "aws_s3_bucket_policy" "bucket_policy" {
-  bucket     = aws_s3_bucket.bucket.*.id[0]
+  count      = var.attach_s3_policy ? 1 : 0
+  bucket     = aws_s3_bucket.bucket.id
   policy     = data.aws_iam_policy_document.policy_document.json
   depends_on = [aws_s3_bucket_public_access_block.bucket_public_access]
 }

--- a/s3_prototype/outputs.tf
+++ b/s3_prototype/outputs.tf
@@ -1,0 +1,4 @@
+output "s3_bucket_policy_json" {
+  description = "s3 bucket policy json intended to be merged with other policies for the bucket built outside of the module if var.attach_s3_policy is false due to circular dependencies."
+  value       = data.aws_iam_policy_document.policy_document.json
+}

--- a/s3_prototype/variables.tf
+++ b/s3_prototype/variables.tf
@@ -1,3 +1,9 @@
+variable "attach_s3_policy" {
+  description = "Whether to attach s3 bucket policy built by the inputted bucket_policy and default policies or not. Only expected to be false if the full bucket policy cannot be passesd in due to a circular dependency"
+  type        = bool
+  default     = true
+}
+
 variable "bucket_name" {}
 
 variable "common_tags" {


### PR DESCRIPTION
Generalise log bucket policy for other log sources such as cloudfront distributions (see https://github.com/nationalarchives/da-ayr-terraform/pull/237)