### PR TITLE
Make attaching of the s3 bucket policy optional

### DIFF
--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -13,7 +13,7 @@ variable "common_tags" {
 }
 
 variable "logging_bucket_policy" {
-  default = ""
+  default = "Additional logging bucket policy to be added to a default policy."
 }
 
 variable "bucket_policy" {

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -13,7 +13,8 @@ variable "common_tags" {
 }
 
 variable "logging_bucket_policy" {
-  default = "Additional logging bucket policy to be added to a default policy."
+  default     = ""
+  description = "Additional logging bucket policy to be added to a default policy."
 }
 
 variable "bucket_policy" {

--- a/s3_logs/main.tf
+++ b/s3_logs/main.tf
@@ -1,6 +1,7 @@
 module "log_bucket" {
   source = "../s3_prototype"
 
+  attach_s3_policy                       = var.attach_s3_policy
   bucket_name                            = var.bucket_name
   common_tags                            = var.common_tags
   bucket_policy                          = var.bucket_policy

--- a/s3_logs/outputs.tf
+++ b/s3_logs/outputs.tf
@@ -1,0 +1,4 @@
+output "s3_bucket_policy_json" {
+  description = "s3 bucket policy json intended to be merged with other policies for the bucket built outside of the module if var.attach_s3_policy is false due to circular dependencies."
+  value       = module.log_bucket.s3_bucket_policy_json
+}

--- a/s3_logs/variables.tf
+++ b/s3_logs/variables.tf
@@ -1,3 +1,9 @@
+variable "attach_s3_policy" {
+  description = "Whether to attach s3 bucket policy built by the inputted bucket_policy and default policies or not. Only expected to be false if the full bucket policy cannot be passesd in due to a circular dependency"
+  type        = bool
+  default     = true
+}
+
 variable "bucket_name" {}
 
 variable "common_tags" {

--- a/s3_prototype/main.tf
+++ b/s3_prototype/main.tf
@@ -65,7 +65,8 @@ data "aws_iam_policy_document" "policy_document" {
 }
 
 resource "aws_s3_bucket_policy" "bucket_policy" {
-  bucket     = aws_s3_bucket.bucket.*.id[0]
+  count      = var.attach_s3_policy ? 1 : 0
+  bucket     = aws_s3_bucket.bucket.id
   policy     = data.aws_iam_policy_document.policy_document.json
   depends_on = [aws_s3_bucket_public_access_block.bucket_public_access]
 }

--- a/s3_prototype/outputs.tf
+++ b/s3_prototype/outputs.tf
@@ -1,0 +1,4 @@
+output "s3_bucket_policy_json" {
+  description = "s3 bucket policy json intended to be merged with other policies for the bucket built outside of the module if var.attach_s3_policy is false due to circular dependencies."
+  value       = data.aws_iam_policy_document.policy_document.json
+}

--- a/s3_prototype/variables.tf
+++ b/s3_prototype/variables.tf
@@ -1,3 +1,9 @@
+variable "attach_s3_policy" {
+  description = "Whether to attach s3 bucket policy built by the inputted bucket_policy and default policies or not. Only expected to be false if the full bucket policy cannot be passesd in due to a circular dependency"
+  type        = bool
+  default     = true
+}
+
 variable "bucket_name" {}
 
 variable "common_tags" {


### PR DESCRIPTION
https://national-archives.atlassian.net/browse/AYR-1274

**Change:**

Make attaching of the s3 bucket policy optional in the s3_prototype and s3 logging modules and output the policy document to attach it outside to deal with scenarios of circular dependency. This PR does not affect the s3 module which creates data bucket and associated log bucket. 

**Motivation:**

Motivation for this was because of the way setting up cloudfront distribution logging works. You need to specify the bucket you want to log to in the distirbuttion resource but at the same time if you want to restrict the logging bucket to only accept s3:PUTs from the distribution, you need to wait for the bucket to be created first so you can reference the arn. Without this change, you get a cyclic dependency.


**Usage example:**

Being used in https://github.com/nationalarchives/da-ayr-terraform/pull/237/files#diff-4c19550ee2608031ac663e5082b80d216f48437aa643ddf8b923275c5fbaf121R100

Specifically here is a terraform plan pointing to this branch: https://github.com/nationalarchives/da-ayr-terraform/actions/runs/11142501638/job/30965578439


**Backwards compatibility:**

Does not affect any existing buckets or policies unless you pass in this new variable `attach_s3_policy` to the s3_logs module or s3_prototype module since the default value is true.

It will on first use destroy the s3 bucket policy but then recreate it because we now use count so the resource that ends  `aws_s3_bucket_policy.bucket_policy` has to be destroyed in favour of identical `aws_s3_bucket_policy.bucket_policy[0]` that gets created.