### PR TITLE
Added extended_statistic input to cloudwatch_alarms module

### DIFF
--- a/cloudwatch_alarms/main.tf
+++ b/cloudwatch_alarms/main.tf
@@ -11,6 +11,7 @@ resource "aws_cloudwatch_metric_alarm" "cloudwatch_metric_alarm" {
   actions_enabled     = var.notification_topic == null ? false : true
   alarm_actions       = var.notification_topic == null ? [] : [var.notification_topic]
   ok_actions          = var.notification_topic == null ? [] : [var.notification_topic]
-  statistic           = var.statistic
+  statistic           = var.extended_statistic == null ? var.statistic : null
+  extended_statistic  = var.extended_statistic
   period              = var.period
 }

--- a/cloudwatch_alarms/main.tf
+++ b/cloudwatch_alarms/main.tf
@@ -1,3 +1,13 @@
+terraform {
+  required_version = ">= 1.6.6"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
 resource "aws_cloudwatch_metric_alarm" "cloudwatch_metric_alarm" {
   alarm_name          = var.name
   comparison_operator = var.comparison_operator

--- a/cloudwatch_alarms/variables.tf
+++ b/cloudwatch_alarms/variables.tf
@@ -49,6 +49,11 @@ variable "statistic" {
   description = "Can be SampleCount, Average, Sum, Minimum, Maximum"
 }
 
+variable "extended_statistic" {
+  default     = null
+  description = "A value between p0.0 and p100. If set statistic will be overriden to null"
+}
+
 variable "comparison_operator" {
   default     = "GreaterThanThreshold"
   description = "Can be GreaterThanOrEqualToThreshold, GreaterThanThreshold, LessThanThreshold, LessThanOrEqualToThreshold"


### PR DESCRIPTION
Added extended_statistic input to cloudwatch_alarms module so we can specify alarms using p statistics as per https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm.html#extended_statistic

Also added Add terraform provider def to the cloudwatch_alarms module so we can override the account it is created in when being created from one stack and to follow best practice... we should do this in all modules.

Needed for: https://github.com/nationalarchives/da-ayr-terraform/pull/246