### PR TITLE
DR2-1945 Allow existing role to be attached.

### DIFF
--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -9,7 +9,7 @@ resource "aws_lambda_function" "lambda_function" {
   count         = var.use_image ? 0 : 1
   function_name = var.function_name
   handler       = var.handler
-  role          = aws_iam_role.lambda_iam_role.arn
+  role          = var.role_arn == null ? aws_iam_role.lambda_iam_role.arn : var.role_arn
   runtime       = var.runtime
   filename      = var.filename == "" ? startswith(var.runtime, "java") ? "${path.module}/functions/generic.jar" : "${path.module}/functions/generic.zip" : var.filename
   timeout       = var.timeout_seconds
@@ -152,7 +152,7 @@ resource "aws_iam_role" "lambda_iam_role" {
 }
 
 resource "aws_iam_policy" "lambda_policies" {
-  for_each = var.policies
+  for_each = var.role_arn == null ? var.policies : {}
   policy   = each.value
   name     = each.key
 }
@@ -164,7 +164,7 @@ resource "aws_iam_role_policy_attachment" "role_policy_attachment" {
 }
 
 resource "aws_iam_role_policy_attachment" "existing_policy_attachment" {
-  for_each   = var.policy_attachments
+  for_each   = var.role_arn == null ? var.policy_attachments : []
   policy_arn = each.value
   role       = aws_iam_role.lambda_iam_role.name
 }

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -108,6 +108,12 @@ variable "policy_attachments" {
   description = "A list of policy arns to attach. These will need to be pre-existing policies"
 }
 
+variable "role_arn" {
+  description = "An existing role to attach to the lambda. If this is provided then policies and policy_attachments will be ignored"
+  default     = null
+  type        = string
+}
+
 variable "log_retention" {
   default = 30
 }


### PR DESCRIPTION
We need to add an existing role to some of our lambda functions. The
module doesn't support this at the moment.
