### PR TITLE
Add optional recurring alarm

### DIFF
--- a/sqs/outputs.tf
+++ b/sqs/outputs.tf
@@ -21,3 +21,7 @@ output "dlq_cloudwatch_message_visible_alarm_arn" {
 output "queue_cloudwatch_message_visible_alarm_arn" {
   value = module.queue_cloudwatch_alarm.cloudwatch_alarm_arn
 }
+
+output "recurring_notification_alarm_arns" {
+  value = [for alarm in aws_cloudwatch_metric_alarm.daily_alert : alarm.arn]
+}

--- a/sqs/variables.tf
+++ b/sqs/variables.tf
@@ -79,3 +79,8 @@ variable "dlq_alarm_messages_visible_period" {
   description = "The period for the metrics for the DLQ alarm visible messages"
   default     = 60
 }
+
+variable "recurring_notification_hour" {
+  type    = number
+  default = null
+}


### PR DESCRIPTION
You can now provide an optional hour and this will create an alarm which
will trigger an alarm state at that hour if there are any messages in
that queue.

It creates an alarm for the main and the dlq queues.

I've also changed the way the queue names are used as we weren't getting alerts from the fifo queues because the alarm didn't use the fifo suffix.