### PR TITLE
overwrite attribute deprecated and not necessary

### DIFF
--- a/ssm_parameter/main.tf
+++ b/ssm_parameter/main.tf
@@ -5,7 +5,6 @@ resource "aws_ssm_parameter" "ssm_parameter" {
   value       = each.value.value
   description = each.value.description
   tier        = each.value.tier
-  overwrite   = each.value.overwrite
   tags        = var.tags
 }
 
@@ -16,7 +15,6 @@ resource "aws_ssm_parameter" "ssm_parameter_ignore_value" {
   value       = each.value.value
   description = each.value.description
   tier        = each.value.tier
-  overwrite   = each.value.overwrite
   tags        = var.tags
   lifecycle {
     ignore_changes = [value]


### PR DESCRIPTION
resource "aws_ssm_parameter" 

The overwrite attribute in the aws_ssm_parameter resource has been deprecated because Terraform now automatically detects and handles parameter overwrites. This simplifies the resource and eliminates the need for explicit overwrite logic, aligning Terraform's behavior with AWS best practices.

In previous versions of Terraform, you had to specify overwrite = true if you wanted to update an existing SSM parameter with a new value. Without this, Terraform would throw an error during a plan or apply operation, stating that the parameter already existed.