### PR TITLE
added AWS Access Analyzer Terraform Module

### DIFF
--- a/.github/workflows/terraform_check.yml
+++ b/.github/workflows/terraform_check.yml
@@ -6,6 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v1
       - uses: nationalarchives/tdr-github-actions/.github/actions/run-git-secrets@main
       - uses: nationalarchives/tdr-github-actions/.github/actions/slack-send@main
         if: failure()

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ Calling modules can choose whatever set of AWS managed rules are most appropriat
 
 Full list of the available AWS managed rules is available here: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html
 
+## AWS Access Analyzer
+
+This Terraform module provisions an **AWS Access Analyzer** instance and optionally defines an **archive rule** to filter findings. The archive rule supports customizable criteria using comparators such as `contains`, `eq`, `exists`, and `neq`.
+
+For detailed usage and configuration, refer to the [Access Analyzer Module README](./access_analyzer/README.md).
+
 ## Using the modules
 You can either clone this repository into the root of your existing terraform project and reference the modules directly
 ```hcl

--- a/access_analyzer/README.md
+++ b/access_analyzer/README.md
@@ -1,0 +1,82 @@
+# AWS Access Analyzer Terraform Module
+
+This Terraform module creates an **AWS Access Analyzer** instance and optionally creates an **archive rule** for filtering findings. The archive rule can be configured with specific criteria to filter access analyzer findings based on multiple comparators like `contains`, `eq`, `exists`, and `neq`.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Inputs](#inputs)
+- [Outputs](#outputs)
+- [Example Usage](#example-usage)
+
+## Overview
+
+- **AWS Access Analyzer**: AWS Access Analyzer helps identify and understand access to AWS resources. It generates findings to detect external access (when resources are accessible by entities outside of the AWS environment) and unused access (when roles, users, or permissions are not being utilized).
+- **Archive Rule**: An archive rule can be created to filter findings based on specific criteria such as user, permissions, or other conditions. This ensures that only relevant results are retained.
+
+
+## Inputs
+
+| Variable Name          | Description                                                                 | Type                                    | Default  | Required |
+| ---------------------- | --------------------------------------------------------------------------- | --------------------------------------- | -------- | -------- |
+| `access_analyzer_name`  | The name of the AWS Access Analyzer instance.                              | `string`                                | **Required** | Yes      |
+| `access_analyzer_type`  | The type of Access Analyzer. Allowed values: `ACCOUNT`, `ORGANIZATION`, `ACCOUNT_UNUSED_ACCESS`, `ORGANIZATION_UNUSED_ACCESS`. | `string`                                | **Required** | Yes      |
+| `unused_access_age`     | The number of days before access is considered unused for unused access analyzers. | `number`                                | `90`     | No       |
+| `create_archive_rule`   | Flag to determine whether an archive rule should be created.               | `bool`                                  | `false`  | No       |
+| `archive_rule_name`     | The name of the archive rule for AWS Access Analyzer.                       | `string`                                | `null`   | No       |
+| `criteria`              | Map of filter criteria for the archive rule. The filter can have `contains`, `eq`, `exists`, and `neq` comparators. | `map(object({ contains = optional(list(string)), eq = optional(list(string)), exists = optional(bool), neq = optional(list(string)) }))` | `{}` | No       |
+| `tags`                 | A map of tags to assign to the AWS Access Analyzer.               | `map(string)`                           | `{}`     | No       |
+
+## Outputs
+
+| Output Name             | Description                                                                 | Value Type                              |
+| ----------------------- | --------------------------------------------------------------------------- | --------------------------------------- |
+| `access_analyzer_name`   | The name of the AWS Access Analyzer instance.                              | `string`                                |
+| `access_analyzer_arn`    | The ARN of the AWS Access Analyzer instance.                               | `string`                                |
+| `archive_rule_name`      | The name of the archive rule (if created).                                 | `string` or `null`                      |
+
+## Example Usage
+
+### Basic Example (Creating an Access Analyzer without Archive Rule)
+```hcl
+module "access_analyzer" {
+  source              = "path/to/this/module"
+  access_analyzer_name = "example-analyzer"
+  access_analyzer_type = "ACCOUNT"
+  tags = {
+    Account = "tna-org"
+  }
+}
+```
+
+### Example with Archive Rule
+```hcl
+module "access_analyzer" {
+  source              = "path/to/this/module"
+  access_analyzer_name = "example-analyzer"
+  access_analyzer_type = "ACCOUNT"
+  create_archive_rule  = true
+  archive_rule_name    = "example-rule"
+  criteria = {
+    "condition.aws:UserId" = {
+      eq = ["userid"]
+    }
+    "error" = {
+      exists = true
+    }
+    "isPublic" = {
+      eq = ["false"]
+    }
+  }
+}
+```
+
+### Notes
+- The module allows the creation of an Access Analyzer instance with a specified type (`ACCOUNT`, `ORGANIZATION`, `ACCOUNT_UNUSED_ACCESS`, or `ORGANIZATION_UNUSED_ACCESS`).
+- Optionally, an archive rule can be created to filter findings based on defined criteria.
+- Each filter criterion must include at least one comparator. Multiple comparators can be used for more complex filtering. The available comparators are:
+  - `contains`: Used to check if the specified value contains the provided items (usually a list of strings).
+  - `eq`: Used to check if the specified value is equal to the provided list of values.
+  - `exists`: A boolean comparator that checks whether the specified criterion exists in the findings.
+  - `neq`: Used to check if the specified value is not equal to the provided list of values.
+- For more information on IAM Access Analyzer filter keys, refer to the [IAM Access Analyzer Filter Keys documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-reference-filter-keys.html).

--- a/access_analyzer/main.tf
+++ b/access_analyzer/main.tf
@@ -1,0 +1,30 @@
+resource "aws_accessanalyzer_analyzer" "access_analyzer" {
+  analyzer_name = var.access_analyzer_name
+  type = var.access_analyzer_type
+  dynamic "configuration" {
+    for_each = contains(["ACCOUNT_UNUSED_ACCESS", "ORGANIZATION_UNUSED_ACCESS"], var.access_analyzer_type) ? [1] : []
+    content {
+      unused_access {
+        unused_access_age = var.unused_access_age
+      }
+    }
+  }
+  tags = var.tags
+}
+
+resource "aws_accessanalyzer_archive_rule" "access_analyzer_archive_rule" {
+  count = var.create_archive_rule ? 1 : 0
+  analyzer_name = aws_accessanalyzer_analyzer.access_analyzer.analyzer_name
+  rule_name = var.archive_rule_name
+  dynamic "filter" {
+    for_each = var.criteria
+    iterator = "criteria"
+    content {
+      criteria = criteria.key
+      contains = lookup(criteria.value, "contains", null)
+      eq       = lookup(criteria.value, "eq", null)
+      exists   = lookup(criteria.value, "exists", null)
+      neq      = lookup(criteria.value, "neq", null)
+    }
+  }
+}

--- a/access_analyzer/main.tf
+++ b/access_analyzer/main.tf
@@ -1,6 +1,6 @@
 resource "aws_accessanalyzer_analyzer" "access_analyzer" {
   analyzer_name = var.access_analyzer_name
-  type = var.access_analyzer_type
+  type          = var.access_analyzer_type
   dynamic "configuration" {
     for_each = contains(["ACCOUNT_UNUSED_ACCESS", "ORGANIZATION_UNUSED_ACCESS"], var.access_analyzer_type) ? [1] : []
     content {
@@ -13,9 +13,9 @@ resource "aws_accessanalyzer_analyzer" "access_analyzer" {
 }
 
 resource "aws_accessanalyzer_archive_rule" "access_analyzer_archive_rule" {
-  count = var.create_archive_rule ? 1 : 0
+  count         = var.create_archive_rule ? 1 : 0
   analyzer_name = aws_accessanalyzer_analyzer.access_analyzer.analyzer_name
-  rule_name = var.archive_rule_name
+  rule_name     = var.archive_rule_name
   dynamic "filter" {
     for_each = var.criteria
     iterator = "criteria"

--- a/access_analyzer/outputs.tf
+++ b/access_analyzer/outputs.tf
@@ -1,0 +1,14 @@
+output "access_analyzer_name" {
+  description = "The name of the AWS Access Analyzer instance."
+  value       = aws_accessanalyzer_analyzer.access_analyzer.analyzer_name
+}
+
+output "access_analyzer_arn" {
+  description = "The ARN of the AWS Access Analyzer instance."
+  value       = aws_accessanalyzer_analyzer.access_analyzer.arn
+}
+
+output "archive_rule_name" {
+  description = "The name of the archive rule (if created)."
+  value       = var.create_archive_rule ? aws_accessanalyzer_archive_rule.access_analyzer_archive_rule[0].rule_name : null
+}

--- a/access_analyzer/variables.tf
+++ b/access_analyzer/variables.tf
@@ -23,7 +23,7 @@ variable "create_archive_rule" {
 variable "archive_rule_name" {
   description = "The name of the archive rule for AWS Access Analyzer."
   type        = string
-  default = null
+  default     = null
 }
 
 variable "criteria" {

--- a/access_analyzer/variables.tf
+++ b/access_analyzer/variables.tf
@@ -1,0 +1,44 @@
+variable "access_analyzer_name" {
+  description = "Name of the AWS Access Analyzer instance"
+  type        = string
+}
+
+variable "access_analyzer_type" {
+  description = "Type of Access Analyzer"
+  type        = string
+}
+
+variable "unused_access_age" {
+  description = "The number of days before access is considered unused for"
+  type        = number
+  default     = 90
+}
+
+variable "create_archive_rule" {
+  description = "Flag to determine whether an archive rule should be created."
+  type        = bool
+  default     = false
+}
+
+variable "archive_rule_name" {
+  description = "The name of the archive rule for AWS Access Analyzer."
+  type        = string
+  default = null
+}
+
+variable "criteria" {
+  description = "Map of filter criteria for Access Analyzer archive rule, with supported comparators."
+  type = map(object({
+    contains = optional(list(string))
+    eq       = optional(list(string))
+    exists   = optional(bool)
+    neq      = optional(list(string))
+  }))
+  default = {}
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the AWS Access Analyzer."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Terraform module for creating an AWS Access Analyzer instance. It creates the following resources:

- An AWS Access Analyzer instance
- Optionally, an archive rule for filtering findings with specific criteria

The module supports configuration of key parameters like analyzer type and archive rule criteria, along with tagging for better resource organization.