### PR TITLE
S3 log / data buckets independent tagging

### DIFF
--- a/s3/main.tf
+++ b/s3/main.tf
@@ -12,13 +12,15 @@ locals {
   log_bucket_count     = var.create_log_bucket ? 1 : 0
   log_bucket_name      = var.create_log_bucket ? "${var.bucket_name}-logs" : var.log_bucket_name
   bucket_logging_count = local.log_bucket_name != "" ? 1 : 0
+  s3_bucket_tags       = merge(var.common_tags, var.s3_data_bucket_additional_tags)
+  s3_log_bucket_tags   = merge(var.common_tags, var.s3_logs_bucket_additional_tags)
 }
 
 module "data_bucket" {
   source = "../s3_prototype"
 
   bucket_name                            = var.bucket_name
-  common_tags                            = var.common_tags
+  common_tags                            = local.s3_bucket_tags
   bucket_policy                          = var.bucket_policy
   abort_incomplete_multipart_upload_days = var.abort_incomplete_multipart_upload_days
 
@@ -32,7 +34,7 @@ module "log_bucket" {
   source = "../s3_logs"
 
   bucket_name = local.log_bucket_name
-  common_tags = var.common_tags
+  common_tags = local.s3_log_bucket_tags
   bucket_policy = var.logging_bucket_policy == "" ? templatefile("${path.module}/templates/default_log_bucket_policy.json.tpl", {
     bucket_name     = var.bucket_name
     log_bucket_name = local.log_bucket_name

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -35,3 +35,13 @@ variable "abort_incomplete_multipart_upload_days" {
   description = "The number of days to keep an incomplete multipart upload before it is deleted"
   default     = 7
 }
+
+variable "s3_data_bucket_additional_tags" {
+  description = "Set of tags to be applied to the S3 bucket only"
+  default     = null
+}
+
+variable "s3_logs_bucket_additional_tags" {
+  description = "Set of tags to be applied to the S3 logs bucket only"
+  default     = null
+}


### PR DESCRIPTION
Allow addittional tags to be set for data and log buckets independently

Support AWS back up work