### PR TITLE
Allow specifying kms_key for s3 logs bucket

### DIFF
--- a/s3_logs/main.tf
+++ b/s3_logs/main.tf
@@ -4,6 +4,7 @@ module "log_bucket" {
   attach_s3_policy                       = var.attach_s3_policy
   bucket_name                            = var.bucket_name
   common_tags                            = var.common_tags
+  kms_key_arn                            = var.kms_key_arn
   bucket_policy                          = var.bucket_policy
   abort_incomplete_multipart_upload_days = var.abort_incomplete_multipart_upload_days
 }

--- a/s3_logs/variables.tf
+++ b/s3_logs/variables.tf
@@ -14,6 +14,10 @@ variable "bucket_policy" {
   default = ""
 }
 
+variable "kms_key_arn" {
+  default = null
+}
+
 variable "abort_incomplete_multipart_upload_days" {
   description = "The number of days to keep an incomplete multipart upload before it is deleted"
   default     = 7


### PR DESCRIPTION
Allow specifying kms_key for s3 logs bucket

Needed for encrypting cloudfront logs, s3 server access logs and cloudtrail logs buckets for backups work.