### PR TITLE
Introduce backups_policy_tag var to s3 modules for deciding whether to backup

### DIFF
--- a/s3/main.tf
+++ b/s3/main.tf
@@ -23,6 +23,7 @@ module "data_bucket" {
   common_tags                            = local.s3_data_bucket_tags
   bucket_policy                          = var.bucket_policy
   abort_incomplete_multipart_upload_days = var.abort_incomplete_multipart_upload_days
+  backup_policy_tag                      = var.backup_policy_tag
 
   kms_key_arn      = var.kms_key_arn
   sns_topic_config = var.sns_topic_config
@@ -42,7 +43,6 @@ module "log_bucket" {
   }) : var.logging_bucket_policy
   abort_incomplete_multipart_upload_days = var.abort_incomplete_multipart_upload_days
 }
-
 
 resource "aws_s3_bucket_logging" "bucket_logging" {
   count = local.bucket_logging_count

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -2,6 +2,12 @@ variable "create_log_bucket" {
   default = true
 }
 
+variable "backup_policy_tag" {
+  description = "The tag used by the central backup system to identify the bucket as a backup target. If not set, the bucket will not be backed up."
+  type        = string
+  default     = ""
+}
+
 variable "log_bucket_name" {
   default = ""
 }

--- a/s3_logs/main.tf
+++ b/s3_logs/main.tf
@@ -7,4 +7,5 @@ module "log_bucket" {
   kms_key_arn                            = var.kms_key_arn
   bucket_policy                          = var.bucket_policy
   abort_incomplete_multipart_upload_days = var.abort_incomplete_multipart_upload_days
+  backup_policy_tag                      = var.backup_policy_tag
 }

--- a/s3_logs/variables.tf
+++ b/s3_logs/variables.tf
@@ -4,6 +4,12 @@ variable "attach_s3_policy" {
   default     = true
 }
 
+variable "backup_policy_tag" {
+  description = "The tag used by the central backup system to identify the bucket as a backup target. If not set, the bucket will not be backed up."
+  type        = string
+  default     = ""
+}
+
 variable "bucket_name" {}
 
 variable "common_tags" {

--- a/s3_prototype/main.tf
+++ b/s3_prototype/main.tf
@@ -3,7 +3,7 @@ resource "aws_s3_bucket" "bucket" {
   tags = merge(
     var.common_tags,
     tomap(
-      { "Name" = var.bucket_name }
+      { "Name" = var.bucket_name, "BackupPolicy" = var.backup_policy_tag }
     )
   )
 }

--- a/s3_prototype/variables.tf
+++ b/s3_prototype/variables.tf
@@ -4,6 +4,12 @@ variable "attach_s3_policy" {
   default     = true
 }
 
+variable "backup_policy_tag" {
+  description = "The tag used by the central backup system to identify the bucket as a backup target. If not set, the bucket will not be backed up."
+  type        = string
+  default     = ""
+}
+
 variable "bucket_name" {}
 
 variable "common_tags" {


### PR DESCRIPTION
Introduce backups_policy_tag var to s3 modules for deciding whether the central backups should back the bucket up. Also use thew tag to dertermine whether to expand the bucket policy to allow backups service access