### PR TITLE
Fix sid for service details for services with fullstop in kms policy

### DIFF
--- a/kms/main.tf
+++ b/kms/main.tf
@@ -168,7 +168,7 @@ data "aws_iam_policy_document" "key_policy" {
   dynamic "statement" {
     for_each = var.default_policy_variables.service_details
     content {
-      sid = "AllowSameAccountServiceAccess${title(statement.value["service_name"])}${index(var.default_policy_variables.service_details, statement.value)}"
+      sid = "AllowSameAccountServiceAccess${title(replace(statement.value["service_name"], "[^a-zA-Z0-9]", "_"))}${index(var.default_policy_variables.service_details, statement.value)}"
       principals {
         type        = "Service"
         identifiers = ["${statement.value["service_name"]}.amazonaws.com"]


### PR DESCRIPTION
Fix sid for service details for services with fullstop in kms policy

As policies can only be alphanumeric and _. Currently it fails for service such as logging.s3 as the . is not allowed, this sanitizes that