### PR TITLE
Add lifecycle rules to main S3 module.

### DIFF
--- a/s3/main.tf
+++ b/s3/main.tf
@@ -27,6 +27,7 @@ module "data_bucket" {
 
   kms_key_arn      = var.kms_key_arn
   sns_topic_config = var.sns_topic_config
+  lifecycle_rules  = var.lifecycle_rules
 }
 
 module "log_bucket" {

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -51,3 +51,9 @@ variable "s3_logs_bucket_additional_tags" {
   description = "Set of tags to be applied to the S3 logs bucket only"
   default     = null
 }
+
+variable "lifecycle_rules" {
+  description = "List of maps describing configuration of object lifecycle management for bucket"
+  type        = any
+  default     = []
+}


### PR DESCRIPTION
I want to add lifecycle rules and specify an existing log bucket which I
don't think I currently can. This should work.
