### PR TITLE
Add REST API policy deployment trigger

### DIFF
--- a/apigateway/locals.tf
+++ b/apigateway/locals.tf
@@ -1,3 +1,4 @@
 locals {
   count_api_rest_policy = var.api_rest_policy == "" ? 0 : 1
+  deployment_triggers   = local.count_api_rest_policy == 1 ? [aws_api_gateway_rest_api_policy.api_rest_policy[0].id] : []
 }

--- a/apigateway/main.tf
+++ b/apigateway/main.tf
@@ -7,7 +7,7 @@ resource "aws_api_gateway_rest_api" "rest_api" {
 resource "aws_api_gateway_deployment" "api_deployment" {
   rest_api_id = aws_api_gateway_rest_api.rest_api.id
   triggers = {
-    redeployment = sha1(jsonencode(aws_api_gateway_rest_api.rest_api.body))
+    redeployment = sha1(jsonencode(concat([aws_api_gateway_rest_api.rest_api.body], local.deployment_triggers)))
   }
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
A deployment of an REST Api is not being triggered if just the REST policy has been updated

Means the API Gateway is not updated unless manual intervention is done to force a deployment

Add a trigger when the REST policy changes to ensure REST Api is updated on a Terraform apply