### PR TITLE
Update KMS policy logic to use strcontains instead of startswith for logs services

### DIFF
--- a/kms/main.tf
+++ b/kms/main.tf
@@ -173,7 +173,7 @@ data "aws_iam_policy_document" "key_policy" {
         type        = "Service"
         identifiers = ["${statement.value["service_name"]}.amazonaws.com"]
       }
-      actions = startswith(statement.value["service_name"], "logs.") ? [
+      actions = strcontains(statement.value["service_name"], "logs") ? [
         "kms:Encrypt*",
         "kms:Decrypt*",
         "kms:ReEncrypt*",


### PR DESCRIPTION
- [CloudFront log delivery to S3 buckets encrypted with KMS requires granting permissions to the delivery.logs.amazonaws.com service](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/standard-logging.html). This service name does not begin with logs., so the previous logic fails to apply the correct set of actions.
- This change ensures that any service name containing "logs" (such as "delivery.logs") receives the broader set of KMS permissions (Encrypt*, Decrypt*, etc.) required for log delivery.
- **Should not affect any downstream modules**. Existing service names that matched the original condition (logs.*) will continue to match under the new logic.