### PR TITLE
adding ECR repo arn as a module output

### DIFF
--- a/ecr/outputs.tf
+++ b/ecr/outputs.tf
@@ -2,3 +2,8 @@ output "repository_url" {
   description = "URL of the ECR repository"
   value       = aws_ecr_repository.repository.repository_url
 }
+
+output "repository_arn" {
+  description = "ARN of the ECR repository"
+  value = aws_ecr_repository.repository.arn
+}

--- a/ecr/outputs.tf
+++ b/ecr/outputs.tf
@@ -5,5 +5,5 @@ output "repository_url" {
 
 output "repository_arn" {
   description = "ARN of the ECR repository"
-  value = aws_ecr_repository.repository.arn
+  value       = aws_ecr_repository.repository.arn
 }


### PR DESCRIPTION
Adding ECR repo ARN as output to allow referencing the ARN directly without needing to duplicate logic or hardcode values.