### PR TITLE
Add IP restrictions options.

### DIFF
--- a/wafv2_aws_managed_rules/main.tf
+++ b/wafv2_aws_managed_rules/main.tf
@@ -1,8 +1,62 @@
+resource "aws_wafv2_ip_set" "allow_list" {
+  count              = length(var.ip_restrictions_configuration.ip_list) > 0 ? 1 : 0
+  name               = "ip-allow-list"
+  addresses          = var.ip_restrictions_configuration.ip_list
+  ip_address_version = "IPV4"
+  scope              = var.scope
+}
+
 resource "aws_wafv2_web_acl" "aws_managed_rules" {
   name  = "AWS-Managed-Rules"
-  scope = "REGIONAL"
-  default_action {
-    block {}
+  scope = var.scope
+  dynamic "default_action" {
+    for_each = var.default_action == "block" ? [""] : []
+    content {
+      block {}
+    }
+  }
+
+  dynamic "default_action" {
+    for_each = var.default_action == "allow" ? [""] : []
+    content {
+      allow {}
+    }
+  }
+
+  dynamic "rule" {
+    for_each = length(var.ip_restrictions_configuration.ip_list) > 0 ? [""] : []
+    content {
+      name     = "AllowIPs"
+      priority = length(var.aws_managed_rules) + 1
+      action {
+        block {}
+      }
+      visibility_config {
+        cloudwatch_metrics_enabled = var.ip_restrictions_configuration.cloudwatch_metrics_enabled
+        metric_name                = "AllowIpMetric"
+        sampled_requests_enabled   = var.ip_restrictions_configuration.sampled_requests_enabled
+      }
+      dynamic "statement" {
+        for_each = var.ip_restrictions_configuration.action == "allow" ? [""] : []
+        content {
+          not_statement {
+            statement {
+              ip_set_reference_statement {
+                arn = aws_wafv2_ip_set.allow_list[0].arn
+              }
+            }
+          }
+        }
+      }
+      dynamic "statement" {
+        for_each = var.ip_restrictions_configuration.action == "block" ? [""] : []
+        content {
+          ip_set_reference_statement {
+            arn = aws_wafv2_ip_set.allow_list[0].arn
+          }
+        }
+      }
+    }
   }
 
   dynamic "rule" {

--- a/wafv2_aws_managed_rules/outputs.tf
+++ b/wafv2_aws_managed_rules/outputs.tf
@@ -1,0 +1,3 @@
+output "waf_arn" {
+  value = aws_wafv2_web_acl.aws_managed_rules.arn
+}

--- a/wafv2_aws_managed_rules/variables.tf
+++ b/wafv2_aws_managed_rules/variables.tf
@@ -4,8 +4,28 @@ variable "log_destinations" {
   default     = []
 }
 
+variable "scope" {
+  default = "REGIONAL"
+}
+
+variable "default_action" {
+  default = "block"
+}
+
 variable "arn_associations" {
   description = "List of AWS resource ARNs for WAF rule association"
+  default     = []
+}
+
+variable "ip_restrictions_configuration" {
+  type = object({
+    ip_list                    = optional(list(string), [])
+    action                     = optional(string, "block")
+    cloudwatch_metrics_enabled = optional(bool, false)
+    sampled_requests_enabled   = optional(bool, false)
+
+  })
+  default = {}
 }
 
 variable "aws_managed_rules" {
@@ -44,4 +64,5 @@ variable "aws_managed_rules" {
 
 variable "tags" {
   description = "tags used across the project"
+  default     = {}
 }


### PR DESCRIPTION
There's a few more configurable parts now so that this can be used for
Cloudfront

These now have a configurable variable
* Default action
* Scope
* IP restrictions

This then adds a statement to the waf rules to either block an IP range
or only allow an ip range.
