### PR TITLE
Remove provider blocks

### DIFF
--- a/cloudwatch_alarms/main.tf
+++ b/cloudwatch_alarms/main.tf
@@ -1,13 +1,3 @@
-terraform {
-  required_version = ">= 1.9.8"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.76.0"
-    }
-  }
-}
-
 resource "aws_cloudwatch_metric_alarm" "cloudwatch_metric_alarm" {
   alarm_name          = var.name
   comparison_operator = var.comparison_operator

--- a/s3/main.tf
+++ b/s3/main.tf
@@ -1,13 +1,3 @@
-terraform {
-  required_version = ">= 1.6.6"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.0"
-    }
-  }
-}
-
 locals {
   log_bucket_count     = var.create_log_bucket ? 1 : 0
   log_bucket_name      = var.create_log_bucket ? "${var.bucket_name}-logs" : var.log_bucket_name


### PR DESCRIPTION
I'm fairly sure they're not needed and we're getting clashes with any
terraform using provider version 6 that uses it.
