### PR TITLE
IAM Roles Anywhere support

### DIFF
--- a/iam_roles_anywhere/README.md
+++ b/iam_roles_anywhere/README.md
@@ -1,0 +1,32 @@
+### iam_roles_anywhere module
+
+This module effectively takes a list of resource access policies and returns a list of (profile, role) ARN pairs as well as creating and returning the ARN of a trust anchor that those profiles trust to verify identity.  Optionally the trust anchor can be specified (by ARN or URL to a .pem bundle) and you can specify allowed source IP ranges for the sesion profile.
+
+What you can't do:
+- reuse existing roles - use the policies from them instead, as managed policies
+- use inline policies - this restriction is inherited from the da_terraform_modules/iam_role module that's used underneath
+- specify a more complex session policy - most things other than IP restrictions belong in the resource policy used in policy_attachments.  You would need to add it manually or add code to this module
+- match other attributes on the certificate e.g. SAN - you would need to add code to this module
+
+Example code to use this module:
+
+```
+module "my_local_system_profile" {
+  source = "git::https://github.com/nationalarchives/da-terraform-modules//iam_roles_anywhere?ref=main"
+  roles = {
+    "my local system" = {
+      x509_subject_cn      = "Dave's local system"
+      policy_attachments   = { "my policy" = local.my_policy_arn }
+      allowed_subnets      = { "Kew site proxy outbound address" = "137.221.134.222/32" }
+    }
+  }
+}
+```
+
+It's recommended to output the following from your code using this module.  Then, every time you terraform apply, it will give you the exact command you can copy and paste for your system to log in with roles anywhere.
+
+```
+output "aws_signin_helper_command" {
+  value = module.backup_AT_uat_profile.aws_signin_helper_command
+}
+```

--- a/iam_roles_anywhere/README.md
+++ b/iam_roles_anywhere/README.md
@@ -4,15 +4,15 @@ This module effectively takes a list of resource access policies and returns a
 list of (profile, role) ARN pairs as well as creating and returning the ARN of
 a trust anchor that those profiles trust to verify identity.  Optionally the
 trust anchor can be specified (by ARN or URL to a .pem bundle) and you can
-specify allowed source IP ranges for the sesion profile.
+specify allowed source IP ranges for the session profile.
 
 What you can't do:
 - reuse existing roles - use the policies from them instead, as managed policies
 - use inline policies - this restriction is inherited from the
   da_terraform_modules/iam_role module that's used underneath
 - specify a more complex session policy - most things other than IP restrictions
-  belong in the resource policy used in policy_attachments.  You would need to
-  add it manually or add code to this module
+  belong in the permissions policy used in policy_attachments.  You would need
+  to add it manually or add code to this module
 - match other attributes on the certificate e.g. SAN - you would need to add
   code to this module
 - have multiple roles with one profile - best practice is for each role to have
@@ -38,13 +38,13 @@ module "lottery_machines_profile" {
   source = "git::https://github.com/nationalarchives/da-terraform-modules//iam_roles_anywhere?ref=main"
   roles = {
     for k in tolist([ "Merlin", "Arthur", "Lancelot", "Guinevere" ]) : k => {
-      x509_subject_cn      = each.value
+      x509_subject_cn      = k
       policy_attachments   = { "web-based RTC access" = local.rtc_policy_arn }
       # optionally restrict by subnet
       allowed_subnets      = k == "Guinevere" ? {
         "Science museum outbound" = local.smip
       } : {
-        "Kew site proxy outbound address" = "137.221.134.222/32"
+        "Secret society outbound range" = "127.121.34.104/29"
       }
     }
   }
@@ -56,7 +56,7 @@ Then, every time you terraform apply, it will give you the exact command you can
 copy and paste for your systems to log in with roles anywhere.
 
 ```
-output "aws_signin_helper_command" {
-  value = module.my_local_system_profile.aws_signin_helper_command
+output "aws_signing_helper_command" {
+  value = module.my_local_system_profile.aws_signing_helper_command
 }
 ```

--- a/iam_roles_anywhere/README.md
+++ b/iam_roles_anywhere/README.md
@@ -27,6 +27,6 @@ It's recommended to output the following from your code using this module.  Then
 
 ```
 output "aws_signin_helper_command" {
-  value = module.backup_AT_uat_profile.aws_signin_helper_command
+  value = module.my_local_system_profile.aws_signin_helper_command
 }
 ```

--- a/iam_roles_anywhere/README.md
+++ b/iam_roles_anywhere/README.md
@@ -1,29 +1,59 @@
 ### iam_roles_anywhere module
 
-This module effectively takes a list of resource access policies and returns a list of (profile, role) ARN pairs as well as creating and returning the ARN of a trust anchor that those profiles trust to verify identity.  Optionally the trust anchor can be specified (by ARN or URL to a .pem bundle) and you can specify allowed source IP ranges for the sesion profile.
+This module effectively takes a list of resource access policies and returns a
+list of (profile, role) ARN pairs as well as creating and returning the ARN of
+a trust anchor that those profiles trust to verify identity.  Optionally the
+trust anchor can be specified (by ARN or URL to a .pem bundle) and you can
+specify allowed source IP ranges for the sesion profile.
 
 What you can't do:
 - reuse existing roles - use the policies from them instead, as managed policies
-- use inline policies - this restriction is inherited from the da_terraform_modules/iam_role module that's used underneath
-- specify a more complex session policy - most things other than IP restrictions belong in the resource policy used in policy_attachments.  You would need to add it manually or add code to this module
-- match other attributes on the certificate e.g. SAN - you would need to add code to this module
+- use inline policies - this restriction is inherited from the
+  da_terraform_modules/iam_role module that's used underneath
+- specify a more complex session policy - most things other than IP restrictions
+  belong in the resource policy used in policy_attachments.  You would need to
+  add it manually or add code to this module
+- match other attributes on the certificate e.g. SAN - you would need to add
+  code to this module
+- have multiple roles with one profile - best practice is for each role to have
+  their own profile.  They can share policies, or a single profile+role can have
+  multiple policies
 
-Example code to use this module:
+Example code to use this module is below.  Note the for comprehension in roles
+object rather than for_each at the top level.  This avoids creating multiple
+identical trust anchors (which will work, but is silly)
 
 ```
 module "my_local_system_profile" {
   source = "git::https://github.com/nationalarchives/da-terraform-modules//iam_roles_anywhere?ref=main"
   roles = {
     "my local system" = {
-      x509_subject_cn      = "Dave's local system"
+      x509_subject_cn      = "Dave's Laptop"
       policy_attachments   = { "my policy" = local.my_policy_arn }
-      allowed_subnets      = { "Kew site proxy outbound address" = "137.221.134.222/32" }
+    }
+  }
+}
+
+module "lottery_machines_profile" {
+  source = "git::https://github.com/nationalarchives/da-terraform-modules//iam_roles_anywhere?ref=main"
+  roles = {
+    for k in tolist([ "Merlin", "Arthur", "Lancelot", "Guinevere" ]) : k => {
+      x509_subject_cn      = each.value
+      policy_attachments   = { "web-based RTC access" = local.rtc_policy_arn }
+      # optionally restrict by subnet
+      allowed_subnets      = k == "Guinevere" ? {
+        "Science museum outbound" = local.smip
+      } : {
+        "Kew site proxy outbound address" = "137.221.134.222/32"
+      }
     }
   }
 }
 ```
 
-It's recommended to output the following from your code using this module.  Then, every time you terraform apply, it will give you the exact command you can copy and paste for your system to log in with roles anywhere.
+It's recommended to output the following from your code using this module.
+Then, every time you terraform apply, it will give you the exact command you can
+copy and paste for your systems to log in with roles anywhere.
 
 ```
 output "aws_signin_helper_command" {

--- a/iam_roles_anywhere/main.tf
+++ b/iam_roles_anywhere/main.tf
@@ -1,31 +1,31 @@
-data "http" "ca-cert-bundle" {
+data "http" "ca_cert_bundle" {
   count = var.trust_anchor_arn == null ? 1 : 0
   url   = var.x509_cert_location
 }
 
-resource "aws_rolesanywhere_trust_anchor" "ds-ca-prod" {
+resource "aws_rolesanywhere_trust_anchor" "trust_anchor" {
   count = var.trust_anchor_arn == null ? 1 : 0
-  name  = "ds-ca-prod"
+  name  = var.trust_anchor_name
   source {
     source_type = "CERTIFICATE_BUNDLE"
     source_data {
-      x509_certificate_data = data.http.ca-cert-bundle[0].response_body
+      x509_certificate_data = data.http.ca_cert_bundle[0].response_body
     }
   }
   enabled = true
 }
 
 locals {
-  trust_anchor_arn = coalesce(var.trust_anchor_arn, aws_rolesanywhere_trust_anchor.ds-ca-prod[0].arn)
+  trust_anchor_arn = var.trust_anchor_arn != null ? var.trust_anchor_arn : aws_rolesanywhere_trust_anchor.trust_anchor[0].arn
 }
 
 # best practice is one certificate per role
 module "iam_role" {
   for_each = var.roles
-  source   = "git::https://github.com/nationalarchives/da-terraform-modules//iam_role?ref=main"
+  source   = "../iam_role"
   name     = each.key
   assume_role_policy = templatefile("${path.module}/templates/ra_role_policy.json.tpl", {
-    anchor_arn      = coalesce(var.trust_anchor_arn, aws_rolesanywhere_trust_anchor.ds-ca-prod[0].arn)
+    anchor_arn      = local.trust_anchor_arn
     x509_subject_cn = each.value.x509_subject_cn
     x509_subject_ou = each.value.x509_subject_ou
   })

--- a/iam_roles_anywhere/main.tf
+++ b/iam_roles_anywhere/main.tf
@@ -1,0 +1,46 @@
+data "http" "ca-cert-bundle" {
+  count = var.trust_anchor_arn == null ? 1 : 0
+  url   = var.x509_cert_location
+}
+
+resource "aws_rolesanywhere_trust_anchor" "ds-ca-prod" {
+  count = var.trust_anchor_arn == null ? 1 : 0
+  name  = "ds-ca-prod"
+  source {
+    source_type = "CERTIFICATE_BUNDLE"
+    source_data {
+      x509_certificate_data = data.http.ca-cert-bundle[0].response_body
+    }
+  }
+  enabled = true
+}
+
+locals {
+  trust_anchor_arn = coalesce(var.trust_anchor_arn, aws_rolesanywhere_trust_anchor.ds-ca-prod[0].arn)
+}
+
+# best practice is one certificate per role
+module "iam_role" {
+  for_each = var.roles
+  source   = "git::https://github.com/nationalarchives/da-terraform-modules//iam_role?ref=main"
+  name     = each.key
+  assume_role_policy = templatefile("${path.module}/templates/ra_role_policy.json.tpl", {
+    anchor_arn      = coalesce(var.trust_anchor_arn, aws_rolesanywhere_trust_anchor.ds-ca-prod[0].arn)
+    x509_subject_cn = each.value.x509_subject_cn
+    x509_subject_ou = each.value.x509_subject_ou
+  })
+  policy_attachments = each.value.policy_attachments
+  tags               = each.value.tags
+}
+
+# best practice is one role per profile
+resource "aws_rolesanywhere_profile" "ra_profiles" {
+  for_each  = var.roles
+  name      = each.key
+  role_arns = [module.iam_role[each.key].role_arn]
+  session_policy = each.value.allowed_subnets == null ? null : templatefile("${path.module}/templates/ip_restriction.json.tpl", {
+    allowed_subnets = values(each.value.allowed_subnets)[*]
+  })
+  enabled = true
+}
+

--- a/iam_roles_anywhere/outputs.tf
+++ b/iam_roles_anywhere/outputs.tf
@@ -1,0 +1,26 @@
+output "trust_anchor_arn" {
+  value       = local.trust_anchor_arn
+  description = "IAM -> Roles -> scroll down -> Manage -> Trust Anchors"
+}
+
+output "profiles" {
+  value = {
+    for k, v in aws_rolesanywhere_profile.ra_profiles :
+    k => { role_arn = module.iam_role[k].role_arn, profile_arn = v.arn }
+  }
+  description = "IAM -> Roles -> scroll down -> Manage -> Profiles (and Roles under that)"
+}
+
+output "aws_signin_helper_command" {
+  value = {
+    for k, v in aws_rolesanywhere_profile.ra_profiles : k => join(" ", [
+      "aws_signing_helper", "credential-process",
+      "--certificate", "${k}.pem",
+      "--private-key", "${k}.key",
+      "--trust-anchor-arn", "${local.trust_anchor_arn}",
+      "--profile-arn", "${v.arn}",
+      "--role-arn", "${module.iam_role[k].role_arn}"
+    ])
+  }
+  description = "output and use this to sign in with Roles Anywhere(TM) using the aws_signin_helper, you may need to change the cert files names"
+}

--- a/iam_roles_anywhere/outputs.tf
+++ b/iam_roles_anywhere/outputs.tf
@@ -4,23 +4,25 @@ output "trust_anchor_arn" {
 }
 
 output "profiles" {
-  value = {
-    for k, v in aws_rolesanywhere_profile.ra_profiles :
-    k => { role_arn = module.iam_role[k].role_arn, profile_arn = v.arn }
-  }
+  value       = aws_rolesanywhere_profile.ra_profiles
   description = "IAM -> Roles -> scroll down -> Manage -> Profiles (and Roles under that)"
 }
 
-output "aws_signin_helper_command" {
+output "roles" {
+  value       = module.iam_role
+  description = "IAM -> Roles -> scroll down -> Manage -> Profiles (and Roles under that)"
+}
+
+output "aws_signing_helper_command" {
   value = {
     for k, v in aws_rolesanywhere_profile.ra_profiles : k => join(" ", [
       "aws_signing_helper", "credential-process",
-      "--certificate", "${k}.pem",
-      "--private-key", "${k}.key",
-      "--trust-anchor-arn", "${local.trust_anchor_arn}",
-      "--profile-arn", "${v.arn}",
-      "--role-arn", "${module.iam_role[k].role_arn}"
+      "--certificate", "'${k}.pem'",
+      "--private-key", "'${k}.key'",
+      "--trust-anchor-arn", "'${local.trust_anchor_arn}'",
+      "--profile-arn", "'${v.arn}'",
+      "--role-arn", "'${module.iam_role[k].role_arn}'"
     ])
   }
-  description = "output and use this to sign in with Roles Anywhere(TM) using the aws_signin_helper, you may need to change the cert files names"
+  description = "output and use this to sign in with Roles Anywhere(TM) using the aws_signing_helper, you may need to change the cert files names"
 }

--- a/iam_roles_anywhere/templates/ip_restriction.json.tpl
+++ b/iam_roles_anywhere/templates/ip_restriction.json.tpl
@@ -1,0 +1,19 @@
+{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "*",
+      "Resource": "*",
+      "Condition": {
+        "IpAddress": {
+          "aws:SourceIp": ${jsonencode(allowed_subnets)
+          }
+        },
+        "Bool": {
+          "aws:ViaAWSService": "false"
+        }
+      }
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/iam_roles_anywhere/templates/ra_role_policy.json.tpl
+++ b/iam_roles_anywhere/templates/ra_role_policy.json.tpl
@@ -1,0 +1,29 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "sts:AssumeRole",
+        "sts:TagSession",
+        "sts:SetSourceIdentity"
+      ],
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "rolesanywhere.amazonaws.com"
+        ]
+      },
+      "Condition": {
+        "ArnEquals": {
+          "aws:SourceArn": [
+            "${anchor_arn}"
+          ]
+        },
+        "StringEquals": {
+          "aws:PrincipalTag/x509Subject/CN": "${x509_subject_cn}",
+          "aws:PrincipalTag/x509Subject/OU": "${x509_subject_ou}"
+        }
+      }
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/iam_roles_anywhere/variables.tf
+++ b/iam_roles_anywhere/variables.tf
@@ -7,7 +7,8 @@ variable "trust_anchor_arn" {
 variable "x509_cert_location" {
   type        = string
   description = "http(s) location of certificate bundle to use for trust anchor.  Ignored if trust_anchor_arn specified"
-  default     = "https://certs.nationalarchives.gov.uk/serverless-ca-bundle.pem"
+  # if your terraform plan is constantly bringing up the pem as a change, make sure it has a trailing newline at the end
+  default = "https://certs.nationalarchives.gov.uk/serverless-ca-bundle.pem"
 }
 
 variable "roles" {

--- a/iam_roles_anywhere/variables.tf
+++ b/iam_roles_anywhere/variables.tf
@@ -1,0 +1,24 @@
+variable "trust_anchor_arn" {
+  type        = string
+  description = "arn of an existing anchor to use which isn't managed by this module, instead of creating the default ds-ca-prod one"
+  default     = null
+}
+
+variable "x509_cert_location" {
+  type        = string
+  description = "http(s) location of certificate bundle to use for trust anchor.  Ignored if trust_anchor_arn specified"
+  default     = "https://certs.nationalarchives.gov.uk/serverless-ca-bundle.pem"
+}
+
+variable "roles" {
+  type = map(object({
+    x509_subject_cn      = string
+    x509_subject_ou      = optional(string, "Digital Archiving")
+    policy_attachments   = optional(map(string), {})
+    tags                 = optional(map(string), {})
+    permissions_boundary = optional(string)
+    max_session_duration = optional(number)
+    allowed_subnets      = optional(map(string))
+  }))
+  description = "roles to create, with subject CN and OU for identifying the role assumer. See iam_role module for details on the rest"
+}

--- a/iam_roles_anywhere/variables.tf
+++ b/iam_roles_anywhere/variables.tf
@@ -4,6 +4,12 @@ variable "trust_anchor_arn" {
   default     = null
 }
 
+variable "trust_anchor_name" {
+  type        = string
+  description = "name to give trust anchor if creating.  Should be specified if x509_cert_location is provided.  Ignored if trust_anchor_arn specified"
+  default     = "ds-ca-prod"
+}
+
 variable "x509_cert_location" {
   type        = string
   description = "http(s) location of certificate bundle to use for trust anchor.  Ignored if trust_anchor_arn specified"


### PR DESCRIPTION
Adds IAM Roles Anywhere module to da_terraform_modules which will be used by our backup to AWS and custodial copy.  I have a local clone of da-bacup-infra which I've been terraform applying into the da dri sandbox account to test this, and it's working beautifully, with the sandbox version of the backup to AWS script using the credentials from it without problems.  Features and usage examples are in the readme
