### PR TITLE
fix(roles_anywhere): session policy needs to allow connections from a…

### DIFF
--- a/iam_roles_anywhere/templates/ip_restriction.json.tpl
+++ b/iam_roles_anywhere/templates/ip_restriction.json.tpl
@@ -8,9 +8,16 @@
         "IpAddress": {
           "aws:SourceIp": ${jsonencode(allowed_subnets)
           }
-        },
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": "*",
+      "Resource": "*",
+      "Condition": {
         "Bool": {
-          "aws:ViaAWSService": "false"
+          "aws:ViaAWSService": "true"
         }
       }
     }


### PR DESCRIPTION
…ws services e.g. for kms retrieval for encrypted buckets

needed for da-backup-infra, the daily bucket has a kms key and it turns out using this gets proxied through sts so the session IP policy won't match the kew outbound proxy IP in this case

Since the session policy only applies an extra layer of restriction that's ANDed with other role permission policies, it's fine for it to be so open-looking.  By itself this session policy doesn't allow anything.