### PR TITLE
NOJIRA Insert the bucket name into bucket policies

### DIFF
--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -14,12 +14,6 @@ variable "log_bucket_name" {
 
 variable "bucket_name" {}
 
-variable "bucket_namespace" {
-  description = "The namespace of the S3 bucket."
-  type        = string
-  default     = "global"
-}
-
 variable "common_tags" {
   default = {}
 }

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -14,6 +14,12 @@ variable "log_bucket_name" {
 
 variable "bucket_name" {}
 
+variable "bucket_namespace" {
+  description = "The namespace of the S3 bucket."
+  type        = string
+  default     = "global"
+}
+
 variable "common_tags" {
   default = {}
 }
@@ -25,7 +31,7 @@ variable "logging_bucket_policy" {
 
 variable "bucket_policy" {
   default     = ""
-  description = "Additional bucket policy to be added to a default policy with sid AllowSSLRequestsOnly that denies non SSL requests."
+  description = "Additional bucket policy to be added to a default policy with sid AllowSSLRequestsOnly that denies non SSL requests. \"<<BUCKET_NAME>>\" will be replaced with the bucket name by this module."
 }
 
 variable "sns_topic_config" {

--- a/s3_prototype/main.tf
+++ b/s3_prototype/main.tf
@@ -109,7 +109,7 @@ data "aws_iam_policy_document" "policy_document" {
 resource "aws_s3_bucket_policy" "bucket_policy" {
   count      = var.attach_s3_policy ? 1 : 0
   bucket     = aws_s3_bucket.bucket.id
-  policy     = data.aws_iam_policy_document.policy_document.json
+  policy     = replace(data.aws_iam_policy_document.policy_document.json, "<<BUCKET_NAME>>", aws_s3_bucket.bucket.id)
   depends_on = [aws_s3_bucket_public_access_block.bucket_public_access]
 }
 

--- a/s3_prototype/variables.tf
+++ b/s3_prototype/variables.tf
@@ -17,7 +17,8 @@ variable "common_tags" {
 }
 
 variable "bucket_policy" {
-  default = ""
+  default     = ""
+  description = "Policy to apply to the bucket. \"<<BUCKET_NAME>>\" will be replaced with the bucket name by this module."
 }
 
 variable "sns_topic_config" {


### PR DESCRIPTION
As the S3 module takes the bucket name and policy as arguments, the policy cannot lookup the name from the bucket when the module is called; the only way to add a bucket policy is to either reference the bucket name as a local or use a wildcard resource (`arn:aws:s3:::*/*` does not work). This adds an additional layer of templating to replace `<<BUCKET_NAME>>` with the name of the bucket when the policy is applied.

I'm not committed to the `<<var>>` syntax and happy to change it, but don't want to confuse this with Terraform's `${var}` syntax and its escaping of `$${var}`.