### PR TITLE
DR2-2937 Output unprocessed message alarm arns

### DIFF
--- a/sqs/main.tf
+++ b/sqs/main.tf
@@ -146,7 +146,7 @@ resource "aws_cloudwatch_metric_alarm" "new_messages_added_to_dlq_alert" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "unprocessed_messages_alert" {
-  for_each            = var.create_dlq ? toset([local.sqs_dlq.name, local.sqs_queue.name]) : toset([local.sqs_queue.name])
+  for_each            = toset([local.sqs_queue.name])
   alarm_name          = "${each.key}-unprocessed-messages-alert"
   alarm_description   = "Triggers when there are messages in the queue but no messages have been recieved for specified period"
   comparison_operator = "GreaterThanThreshold"

--- a/sqs/main.tf
+++ b/sqs/main.tf
@@ -146,8 +146,7 @@ resource "aws_cloudwatch_metric_alarm" "new_messages_added_to_dlq_alert" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "unprocessed_messages_alert" {
-  for_each            = toset([local.sqs_queue.name])
-  alarm_name          = "${each.key}-unprocessed-messages-alert"
+  alarm_name          = "${local.sqs_queue.name}-unprocessed-messages-alert"
   alarm_description   = "Triggers when there are messages in the queue but no messages have been recieved for specified period"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
@@ -162,7 +161,7 @@ resource "aws_cloudwatch_metric_alarm" "unprocessed_messages_alert" {
       period      = var.messages_visible_alarm_period
       namespace   = "AWS/SQS"
       dimensions = {
-        QueueName = each.key
+        QueueName = local.sqs_queue.name
       }
     }
   }
@@ -175,7 +174,7 @@ resource "aws_cloudwatch_metric_alarm" "unprocessed_messages_alert" {
       period      = var.messages_visible_alarm_period
       namespace   = "AWS/SQS"
       dimensions = {
-        QueueName = each.key
+        QueueName = local.sqs_queue.name
       }
     }
   }

--- a/sqs/outputs.tf
+++ b/sqs/outputs.tf
@@ -22,8 +22,8 @@ output "event_alarms" {
   value = aws_cloudwatch_metric_alarm.new_messages_added_to_dlq_alert.*.arn
 }
 
-output "unprocessed_message_alarms" {
-  value = aws_cloudwatch_metric_alarm.unprocessed_messages_alert.*.arn
+output "unprocessed_message_alarm" {
+  value = aws_cloudwatch_metric_alarm.unprocessed_messages_alert.arn
 }
 
 output "sqs_queue" {

--- a/sqs/outputs.tf
+++ b/sqs/outputs.tf
@@ -22,6 +22,10 @@ output "event_alarms" {
   value = aws_cloudwatch_metric_alarm.new_messages_added_to_dlq_alert.*.arn
 }
 
+output "unprocessed_alarms" {
+  value = aws_cloudwatch_metric_alarm.unprocessed_messages_alert.*.arn
+}
+
 output "sqs_queue" {
   value = local.sqs_queue
 }

--- a/sqs/outputs.tf
+++ b/sqs/outputs.tf
@@ -22,7 +22,7 @@ output "event_alarms" {
   value = aws_cloudwatch_metric_alarm.new_messages_added_to_dlq_alert.*.arn
 }
 
-output "unprocessed_alarms" {
+output "unprocessed_message_alarms" {
   value = aws_cloudwatch_metric_alarm.unprocessed_messages_alert.*.arn
 }
 


### PR DESCRIPTION
We want to alert on these if they trigger so we need to output them first.

Also remove the DLQ because having unprocesed message alarms on those doesn't make sense.
